### PR TITLE
implement standalone notification module

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -10,6 +10,7 @@ import { ChangeLogModule } from "./change-log/change-log.module";
 import { BarcodeModule } from "./barcode/barcode.module";
 import { ScheduleModule } from "@nestjs/schedule";
 import { ComplianceModule } from "./compliance/compliance.module";
+import { NotificationsModule } from "./notifications/notifications.module";
 
 @Module({
   imports: [
@@ -41,6 +42,7 @@ import { ComplianceModule } from "./compliance/compliance.module";
     PolicyDocumentsModule,
     WarrantyModule,
     DeviceHealthModule,
+    NotificationsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/notifications/notification-template.entity.ts
+++ b/backend/src/notifications/notification-template.entity.ts
@@ -1,0 +1,28 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from "typeorm";
+
+@Entity("notification_templates")
+export class NotificationTemplate {
+  @PrimaryGeneratedColumn("uuid")
+  id: string;
+
+  @Column()
+  type: string;
+
+  @Column("text")
+  subject: string;
+
+  @Column("text")
+  body: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/notifications/notification.entity.ts
+++ b/backend/src/notifications/notification.entity.ts
@@ -1,0 +1,31 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from "typeorm";
+
+@Entity("notifications")
+export class Notification {
+  @PrimaryGeneratedColumn("uuid")
+  id: string;
+
+  @Column()
+  type: string;
+
+  @Column("text")
+  message: string;
+
+  @Column()
+  recipientId: string;
+
+  @Column({ default: "unread" })
+  status: "unread" | "read" | "sent";
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}


### PR DESCRIPTION
Notification and NotificationTemplate entities.
Service for CRUD, querying, and mock email (nodemailer) support.
Controller for managing templates and user notifications.
Module is imported in [app.module.ts](vscode-file://vscode-app/c:/Users/Surface/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for use across the backend.