### PR TITLE
feat(status-history): standalone module to track asset status changes

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -16,6 +16,7 @@ import { PolicyDocumentsModule } from "./policy-documents/policy-documents.modul
 import { DeviceHealthModule } from "./device-health/device-health.module";
 import { QRCodeModule } from "./QR-Code/qrcode.module";
 import { NotificationsModule } from "./notifications/notifications.module";
+import { StatusHistoryModule } from "./status-history/status-history.module";
 
 @Module({
   imports: [
@@ -49,6 +50,7 @@ import { NotificationsModule } from "./notifications/notifications.module";
     DeviceHealthModule,
     QRCodeModule,
     NotificationsModule,
+    StatusHistoryModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/status-history/dto/create-status-history.dto.ts
+++ b/backend/src/status-history/dto/create-status-history.dto.ts
@@ -1,0 +1,23 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsNotEmpty, IsString } from 'class-validator';
+import { AssetStatus } from '../entities/status-history.entity';
+
+export class CreateStatusHistoryDto {
+  @ApiProperty({ description: 'Asset ID (mock ref)' })
+  @IsString()
+  @IsNotEmpty()
+  assetId: string;
+
+  @ApiProperty({ enum: AssetStatus })
+  @IsEnum(AssetStatus)
+  previousStatus: AssetStatus;
+
+  @ApiProperty({ enum: AssetStatus })
+  @IsEnum(AssetStatus)
+  newStatus: AssetStatus;
+
+  @ApiProperty({ description: 'User identifier who made the change' })
+  @IsString()
+  @IsNotEmpty()
+  changedBy: string;
+}

--- a/backend/src/status-history/entities/status-history.entity.ts
+++ b/backend/src/status-history/entities/status-history.entity.ts
@@ -1,0 +1,38 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+export enum AssetStatus {
+  ACTIVE = 'active',
+  UNDER_MAINTENANCE = 'under_maintenance',
+  IN_TRANSFER = 'in_transfer',
+  DISPOSED = 'disposed',
+}
+
+@Entity('status_history')
+@Index(['assetId'])
+@Index(['changeDate'])
+export class StatusHistory {
+  @ApiProperty()
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ApiProperty({ description: 'ID of the asset (mock reference, no FK)' })
+  @Column()
+  assetId: string;
+
+  @ApiProperty({ enum: AssetStatus })
+  @Column({ type: 'enum', enum: AssetStatus })
+  previousStatus: AssetStatus;
+
+  @ApiProperty({ enum: AssetStatus })
+  @Column({ type: 'enum', enum: AssetStatus })
+  newStatus: AssetStatus;
+
+  @ApiProperty({ description: 'When the status changed' })
+  @CreateDateColumn()
+  changeDate: Date;
+
+  @ApiProperty({ description: 'User identifier who made the change' })
+  @Column()
+  changedBy: string;
+}

--- a/backend/src/status-history/status-history.controller.ts
+++ b/backend/src/status-history/status-history.controller.ts
@@ -1,0 +1,20 @@
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { StatusHistoryService } from './status-history.service';
+import { CreateStatusHistoryDto } from './dto/create-status-history.dto';
+
+@ApiTags('status-history')
+@Controller('status-history')
+export class StatusHistoryController {
+  constructor(private readonly service: StatusHistoryService) {}
+
+  @Post()
+  async create(@Body() dto: CreateStatusHistoryDto) {
+    return this.service.logStatusChange(dto);
+  }
+
+  @Get(':assetId')
+  async getByAsset(@Param('assetId') assetId: string) {
+    return this.service.getByAsset(assetId);
+  }
+}

--- a/backend/src/status-history/status-history.e2e-spec.ts
+++ b/backend/src/status-history/status-history.e2e-spec.ts
@@ -1,0 +1,62 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import * as request from 'supertest';
+import { StatusHistoryModule } from './status-history.module';
+import { StatusHistory } from './entities/status-history.entity';
+
+describe('StatusHistoryController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'sqlite',
+          database: ':memory:',
+          entities: [StatusHistory],
+          synchronize: true,
+        }),
+        StatusHistoryModule,
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('POST /status-history should create a status history record', async () => {
+    const dto = {
+      assetId: 'asset-123',
+      previousStatus: 'active',
+      newStatus: 'under_maintenance',
+      changedBy: 'tester',
+    };
+
+    const res = await request(app.getHttpServer())
+      .post('/status-history')
+      .send(dto)
+      .expect(201);
+
+    expect(res.body).toHaveProperty('id');
+    expect(res.body.assetId).toBe(dto.assetId);
+    expect(res.body.previousStatus).toBe(dto.previousStatus);
+    expect(res.body.newStatus).toBe(dto.newStatus);
+    expect(res.body.changedBy).toBe(dto.changedBy);
+    expect(res.body).toHaveProperty('changeDate');
+  });
+
+  it('GET /status-history/:assetId should return records for asset', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/status-history/asset-123')
+      .expect(200);
+
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBeGreaterThanOrEqual(1);
+    expect(res.body[0]).toHaveProperty('assetId', 'asset-123');
+  });
+});

--- a/backend/src/status-history/status-history.module.ts
+++ b/backend/src/status-history/status-history.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { StatusHistory } from './entities/status-history.entity';
+import { StatusHistoryService } from './status-history.service';
+import { StatusHistoryController } from './status-history.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([StatusHistory])],
+  controllers: [StatusHistoryController],
+  providers: [StatusHistoryService],
+  exports: [StatusHistoryService],
+})
+export class StatusHistoryModule {}

--- a/backend/src/status-history/status-history.service.spec.ts
+++ b/backend/src/status-history/status-history.service.spec.ts
@@ -1,0 +1,81 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { StatusHistoryService } from './status-history.service';
+import { StatusHistory, AssetStatus } from './entities/status-history.entity';
+import { CreateStatusHistoryDto } from './dto/create-status-history.dto';
+
+
+describe('StatusHistoryService', () => {
+  let service: StatusHistoryService;
+  let repository: jest.Mocked<Partial<Repository<StatusHistory>>>;
+
+  beforeEach(async () => {
+    repository = {
+      create: jest.fn(),
+      save: jest.fn(),
+      find: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StatusHistoryService,
+        {
+          provide: getRepositoryToken(StatusHistory),
+          useValue: repository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<StatusHistoryService>(StatusHistoryService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('logStatusChange', () => {
+    it('creates and saves a status history record', async () => {
+      const dto: CreateStatusHistoryDto = {
+        assetId: 'asset-1',
+        previousStatus: AssetStatus.ACTIVE,
+        newStatus: AssetStatus.UNDER_MAINTENANCE,
+        changedBy: 'user-1',
+      };
+
+      const created: Partial<StatusHistory> = { id: 'id-1', ...dto };
+      (repository.create as jest.Mock).mockReturnValue(created);
+      (repository.save as jest.Mock).mockResolvedValue(created);
+
+      const result = await service.logStatusChange(dto);
+
+      expect(repository.create).toHaveBeenCalledWith({
+        assetId: dto.assetId,
+        previousStatus: dto.previousStatus,
+        newStatus: dto.newStatus,
+        changedBy: dto.changedBy,
+      });
+      expect(repository.save).toHaveBeenCalledWith(created);
+      expect(result).toEqual(created);
+    });
+  });
+
+  describe('getByAsset', () => {
+    it('returns records ordered by changeDate desc', async () => {
+      const assetId = 'asset-1';
+      const records: StatusHistory[] = [
+        { id: '2', assetId, previousStatus: AssetStatus.IN_TRANSFER, newStatus: AssetStatus.ACTIVE, changeDate: new Date(), changedBy: 'u2' },
+        { id: '1', assetId, previousStatus: AssetStatus.ACTIVE, newStatus: AssetStatus.IN_TRANSFER, changeDate: new Date(), changedBy: 'u1' },
+      ] as StatusHistory[];
+      (repository.find as jest.Mock).mockResolvedValue(records);
+
+      const res = await service.getByAsset(assetId);
+
+      expect(repository.find).toHaveBeenCalledWith({
+        where: { assetId },
+        order: { changeDate: 'DESC' },
+      });
+      expect(res).toBe(records);
+    });
+  });
+});

--- a/backend/src/status-history/status-history.service.ts
+++ b/backend/src/status-history/status-history.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { StatusHistory, AssetStatus } from './entities/status-history.entity';
+import { CreateStatusHistoryDto } from './dto/create-status-history.dto';
+
+@Injectable()
+export class StatusHistoryService {
+  constructor(
+    @InjectRepository(StatusHistory)
+    private readonly repo: Repository<StatusHistory>,
+  ) {}
+
+  async logStatusChange(dto: CreateStatusHistoryDto): Promise<StatusHistory> {
+    const record = this.repo.create({
+      assetId: dto.assetId,
+      previousStatus: dto.previousStatus,
+      newStatus: dto.newStatus,
+      changedBy: dto.changedBy,
+      // changeDate is auto via @CreateDateColumn
+    });
+    return this.repo.save(record);
+  }
+
+  async getByAsset(assetId: string): Promise<StatusHistory[]> {
+    return this.repo.find({
+      where: { assetId },
+      order: { changeDate: 'DESC' },
+    });
+  }
+}


### PR DESCRIPTION
closes #103 

Summary
Adds an isolated status-history module to record and query asset status transitions over time, independent of the Asset module.

Scope
Independent storage for status history with a mock assetId (no FK).
Consistent status values via AssetStatus enum.
Endpoints to log and fetch status changes.
Changes
Entity and enums:
backend/src/status-history/entities/status-history.entity.ts
StatusHistory
 fields: assetId, previousStatus, newStatus, changeDate, changedBy.
AssetStatus enum: active, under_maintenance, in_transfer, disposed.
Indices on assetId, changeDate.
DTOs:
backend/src/status-history/dto/create-status-history.dto.ts
Service:
backend/src/status-history/status-history.service.ts
logStatusChange(dto)
getByAsset(assetId)
Controller:
backend/src/status-history/status-history.controller.ts
POST /status-history
GET /status-history/:assetId
Module wiring:
backend/src/status-history/status-history.module.ts
backend/src/app.module.ts
 imports 
StatusHistoryModule
Tests:
Unit: 
backend/src/status-history/status-history.service.spec.ts
E2E: 
backend/src/status-history/status-history.e2e-spec.ts
 (SQLite in-memory)
Technical Notes
Uses TypeORM enums and @CreateDateColumn for changeDate.
Decoupled from Asset module; assetId is an opaque string.
API tagged status-history for Swagger.
Testing
Unit tests validate creation and query ordering.
E2E tests create and retrieve status history via HTTP using an in-memory SQLite database.
Migration
If synchronize is disabled in production, add a migration to create status_history table with enum columns and indexes.
