### PR TITLE
implement full CRUD operations for countries and currencies

### DIFF
--- a/backend/src/country-currency/country-currency.controller.ts
+++ b/backend/src/country-currency/country-currency.controller.ts
@@ -1,0 +1,106 @@
+import { Controller, Get, Post, Patch, Delete } from "@nestjs/common"
+import type { CountryCurrencyService } from "./country-currency.service"
+import type { CreateCountryDto } from "./dto/create-country.dto"
+import type { UpdateCountryDto } from "./dto/update-country.dto"
+import type { CreateCurrencyDto } from "./dto/create-currency.dto"
+import type { UpdateCurrencyDto } from "./dto/update-currency.dto"
+import type { ExchangeRateUpdateDto } from "./dto/exchange-rate-update.dto"
+
+@Controller("country-currency")
+export class CountryCurrencyController {
+  constructor(private readonly countryCurrencyService: CountryCurrencyService) {}
+
+  // Country endpoints
+  @Post("countries")
+  createCountry(createCountryDto: CreateCountryDto) {
+    return this.countryCurrencyService.createCountry(createCountryDto)
+  }
+
+  @Get("countries")
+  findAllCountries(activeOnly?: string) {
+    if (activeOnly === "true") {
+      return this.countryCurrencyService.findActiveCountries()
+    }
+    return this.countryCurrencyService.findAllCountries()
+  }
+
+  @Get("countries/:id")
+  findCountryById(id: string) {
+    return this.countryCurrencyService.findCountryById(id)
+  }
+
+  @Get("countries/iso/:isoCode")
+  findCountryByIsoCode(isoCode: string) {
+    return this.countryCurrencyService.findCountryByIsoCode(isoCode)
+  }
+
+  @Patch("countries/:id")
+  updateCountry(id: string, updateCountryDto: UpdateCountryDto) {
+    return this.countryCurrencyService.updateCountry(id, updateCountryDto)
+  }
+
+  @Delete("countries/:id")
+  removeCountry(id: string) {
+    return this.countryCurrencyService.removeCountry(id)
+  }
+
+  // Currency endpoints
+  @Post("currencies")
+  createCurrency(createCurrencyDto: CreateCurrencyDto) {
+    return this.countryCurrencyService.createCurrency(createCurrencyDto)
+  }
+
+  @Get("currencies")
+  findAllCurrencies(activeOnly?: string) {
+    if (activeOnly === "true") {
+      return this.countryCurrencyService.findActiveCurrencies()
+    }
+    return this.countryCurrencyService.findAllCurrencies()
+  }
+
+  @Get("currencies/base")
+  getBaseCurrency() {
+    return this.countryCurrencyService.getBaseCurrency()
+  }
+
+  @Get("currencies/:id")
+  findCurrencyById(id: string) {
+    return this.countryCurrencyService.findCurrencyById(id)
+  }
+
+  @Get("currencies/code/:code")
+  findCurrencyByCode(code: string) {
+    return this.countryCurrencyService.findCurrencyByCode(code)
+  }
+
+  @Patch("currencies/:id")
+  updateCurrency(id: string, updateCurrencyDto: UpdateCurrencyDto) {
+    return this.countryCurrencyService.updateCurrency(id, updateCurrencyDto)
+  }
+
+  @Patch("currencies/:id/exchange-rate")
+  updateExchangeRate(id: string, exchangeRateDto: ExchangeRateUpdateDto) {
+    return this.countryCurrencyService.updateExchangeRate(id, exchangeRateDto)
+  }
+
+  @Post("currencies/exchange-rates/bulk")
+  bulkUpdateExchangeRates(rates: { currencyCode: string; rate: number }[]) {
+    return this.countryCurrencyService.bulkUpdateExchangeRates(rates)
+  }
+
+  @Get("currencies/convert/:amount/:from/:to")
+  convertCurrency(amount: string, from: string, to: string) {
+    return this.countryCurrencyService.convertCurrency(Number.parseFloat(amount), from, to)
+  }
+
+  @Get("currencies/:id/history")
+  getExchangeRateHistory(id: string, days?: string) {
+    const daysNumber = days ? Number.parseInt(days) : 30
+    return this.countryCurrencyService.getExchangeRateHistory(id, daysNumber)
+  }
+
+  @Delete("currencies/:id")
+  removeCurrency(id: string) {
+    return this.countryCurrencyService.removeCurrency(id)
+  }
+}

--- a/backend/src/country-currency/country-currency.module.ts
+++ b/backend/src/country-currency/country-currency.module.ts
@@ -1,0 +1,14 @@
+import { Module } from "@nestjs/common"
+import { TypeOrmModule } from "@nestjs/typeorm"
+import { CountryCurrencyService } from "./country-currency.service"
+import { CountryCurrencyController } from "./country-currency.controller"
+import { Country } from "./entities/country.entity"
+import { Currency } from "./entities/currency.entity"
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Country, Currency])],
+  controllers: [CountryCurrencyController],
+  providers: [CountryCurrencyService],
+  exports: [CountryCurrencyService, TypeOrmModule],
+})
+export class CountryCurrencyModule {}

--- a/backend/src/country-currency/country-currency.service.ts
+++ b/backend/src/country-currency/country-currency.service.ts
@@ -1,0 +1,218 @@
+import { Injectable, NotFoundException, BadRequestException } from "@nestjs/common"
+import type { Repository } from "typeorm"
+import type { Country } from "./entities/country.entity"
+import type { Currency } from "./entities/currency.entity"
+import type { CreateCountryDto } from "./dto/create-country.dto"
+import type { UpdateCountryDto } from "./dto/update-country.dto"
+import type { CreateCurrencyDto } from "./dto/create-currency.dto"
+import type { UpdateCurrencyDto } from "./dto/update-currency.dto"
+import type { ExchangeRateUpdateDto } from "./dto/exchange-rate-update.dto"
+
+@Injectable()
+export class CountryCurrencyService {
+  constructor(
+    private countryRepository: Repository<Country>,
+    private currencyRepository: Repository<Currency>,
+  ) {}
+
+  // Country methods
+  async createCountry(createCountryDto: CreateCountryDto): Promise<Country> {
+    const country = this.countryRepository.create(createCountryDto)
+    return await this.countryRepository.save(country)
+  }
+
+  async findAllCountries(): Promise<Country[]> {
+    return await this.countryRepository.find({
+      relations: ["currencies"],
+      order: { name: "ASC" },
+    })
+  }
+
+  async findActiveCountries(): Promise<Country[]> {
+    return await this.countryRepository.find({
+      where: { isActive: true },
+      relations: ["currencies"],
+      order: { name: "ASC" },
+    })
+  }
+
+  async findCountryById(id: string): Promise<Country> {
+    const country = await this.countryRepository.findOne({
+      where: { id },
+      relations: ["currencies"],
+    })
+    if (!country) {
+      throw new NotFoundException(`Country with ID ${id} not found`)
+    }
+    return country
+  }
+
+  async findCountryByIsoCode(isoCode: string): Promise<Country> {
+    const country = await this.countryRepository.findOne({
+      where: [{ isoCode2: isoCode.toUpperCase() }, { isoCode3: isoCode.toUpperCase() }],
+      relations: ["currencies"],
+    })
+    if (!country) {
+      throw new NotFoundException(`Country with ISO code ${isoCode} not found`)
+    }
+    return country
+  }
+
+  async updateCountry(id: string, updateCountryDto: UpdateCountryDto): Promise<Country> {
+    const country = await this.findCountryById(id)
+    Object.assign(country, updateCountryDto)
+    return await this.countryRepository.save(country)
+  }
+
+  async removeCountry(id: string): Promise<void> {
+    const country = await this.findCountryById(id)
+    await this.countryRepository.remove(country)
+  }
+
+  // Currency methods
+  async createCurrency(createCurrencyDto: CreateCurrencyDto): Promise<Currency> {
+    if (createCurrencyDto.countryId) {
+      await this.findCountryById(createCurrencyDto.countryId)
+    }
+
+    // Ensure only one base currency exists
+    if (createCurrencyDto.isBaseCurrency) {
+      await this.currencyRepository.update({ isBaseCurrency: true }, { isBaseCurrency: false })
+    }
+
+    const currency = this.currencyRepository.create({
+      ...createCurrencyDto,
+      exchangeRateUpdatedAt: new Date(),
+    })
+    return await this.currencyRepository.save(currency)
+  }
+
+  async findAllCurrencies(): Promise<Currency[]> {
+    return await this.currencyRepository.find({
+      relations: ["country"],
+      order: { code: "ASC" },
+    })
+  }
+
+  async findActiveCurrencies(): Promise<Currency[]> {
+    return await this.currencyRepository.find({
+      where: { isActive: true },
+      relations: ["country"],
+      order: { code: "ASC" },
+    })
+  }
+
+  async findCurrencyById(id: string): Promise<Currency> {
+    const currency = await this.currencyRepository.findOne({
+      where: { id },
+      relations: ["country"],
+    })
+    if (!currency) {
+      throw new NotFoundException(`Currency with ID ${id} not found`)
+    }
+    return currency
+  }
+
+  async findCurrencyByCode(code: string): Promise<Currency> {
+    const currency = await this.currencyRepository.findOne({
+      where: { code: code.toUpperCase() },
+      relations: ["country"],
+    })
+    if (!currency) {
+      throw new NotFoundException(`Currency with code ${code} not found`)
+    }
+    return currency
+  }
+
+  async getBaseCurrency(): Promise<Currency> {
+    const baseCurrency = await this.currencyRepository.findOne({
+      where: { isBaseCurrency: true },
+      relations: ["country"],
+    })
+    if (!baseCurrency) {
+      throw new NotFoundException("No base currency configured")
+    }
+    return baseCurrency
+  }
+
+  async updateCurrency(id: string, updateCurrencyDto: UpdateCurrencyDto): Promise<Currency> {
+    const currency = await this.findCurrencyById(id)
+
+    if (updateCurrencyDto.countryId) {
+      await this.findCountryById(updateCurrencyDto.countryId)
+    }
+
+    // Ensure only one base currency exists
+    if (updateCurrencyDto.isBaseCurrency && !currency.isBaseCurrency) {
+      await this.currencyRepository.update({ isBaseCurrency: true }, { isBaseCurrency: false })
+    }
+
+    Object.assign(currency, updateCurrencyDto)
+    return await this.currencyRepository.save(currency)
+  }
+
+  async updateExchangeRate(id: string, exchangeRateDto: ExchangeRateUpdateDto): Promise<Currency> {
+    const currency = await this.findCurrencyById(id)
+
+    currency.exchangeRateToUSD = exchangeRateDto.exchangeRateToUSD
+    currency.exchangeRateUpdatedAt = exchangeRateDto.exchangeRateUpdatedAt || new Date()
+
+    return await this.currencyRepository.save(currency)
+  }
+
+  async bulkUpdateExchangeRates(rates: { currencyCode: string; rate: number }[]): Promise<Currency[]> {
+    const updatedCurrencies: Currency[] = []
+
+    for (const rateUpdate of rates) {
+      try {
+        const currency = await this.findCurrencyByCode(rateUpdate.currencyCode)
+        currency.exchangeRateToUSD = rateUpdate.rate
+        currency.exchangeRateUpdatedAt = new Date()
+        const updated = await this.currencyRepository.save(currency)
+        updatedCurrencies.push(updated)
+      } catch (error) {
+        console.warn(`Failed to update exchange rate for ${rateUpdate.currencyCode}:`, error.message)
+      }
+    }
+
+    return updatedCurrencies
+  }
+
+  async convertCurrency(amount: number, fromCurrencyCode: string, toCurrencyCode: string): Promise<number> {
+    if (fromCurrencyCode === toCurrencyCode) {
+      return amount
+    }
+
+    const fromCurrency = await this.findCurrencyByCode(fromCurrencyCode)
+    const toCurrency = await this.findCurrencyByCode(toCurrencyCode)
+
+    // Convert to USD first, then to target currency
+    const usdAmount = amount / fromCurrency.exchangeRateToUSD
+    const convertedAmount = usdAmount * toCurrency.exchangeRateToUSD
+
+    return Math.round(convertedAmount * Math.pow(10, toCurrency.decimalPlaces)) / Math.pow(10, toCurrency.decimalPlaces)
+  }
+
+  async removeCurrency(id: string): Promise<void> {
+    const currency = await this.findCurrencyById(id)
+
+    if (currency.isBaseCurrency) {
+      throw new BadRequestException("Cannot delete the base currency")
+    }
+
+    await this.currencyRepository.remove(currency)
+  }
+
+  async getExchangeRateHistory(currencyId: string, days = 30): Promise<any[]> {
+    // This would typically query a separate exchange rate history table
+    // For now, return the current rate as a placeholder
+    const currency = await this.findCurrencyById(currencyId)
+    return [
+      {
+        date: currency.exchangeRateUpdatedAt,
+        rate: currency.exchangeRateToUSD,
+        currencyCode: currency.code,
+      },
+    ]
+  }
+}

--- a/backend/src/country-currency/dto/create-country.dto.ts
+++ b/backend/src/country-currency/dto/create-country.dto.ts
@@ -1,0 +1,37 @@
+import { IsString, IsNotEmpty, Length, IsOptional, IsBoolean } from "class-validator"
+
+export class CreateCountryDto {
+  @IsString()
+  @IsNotEmpty()
+  @Length(1, 100)
+  name: string
+
+  @IsString()
+  @IsNotEmpty()
+  @Length(2, 2)
+  isoCode2: string
+
+  @IsString()
+  @IsNotEmpty()
+  @Length(3, 3)
+  isoCode3: string
+
+  @IsString()
+  @IsNotEmpty()
+  @Length(3, 3)
+  numericCode: string
+
+  @IsString()
+  @IsNotEmpty()
+  @Length(1, 100)
+  region: string
+
+  @IsString()
+  @IsNotEmpty()
+  @Length(1, 100)
+  subRegion: string
+
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean
+}

--- a/backend/src/country-currency/dto/create-currency.dto.ts
+++ b/backend/src/country-currency/dto/create-currency.dto.ts
@@ -1,0 +1,40 @@
+import { IsString, IsNotEmpty, Length, IsOptional, IsBoolean, IsNumber, IsUUID, Min } from "class-validator"
+
+export class CreateCurrencyDto {
+  @IsString()
+  @IsNotEmpty()
+  @Length(3, 3)
+  code: string
+
+  @IsString()
+  @IsNotEmpty()
+  @Length(1, 100)
+  name: string
+
+  @IsString()
+  @IsNotEmpty()
+  @Length(1, 10)
+  symbol: string
+
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 6 })
+  @Min(0)
+  exchangeRateToUSD?: number
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  decimalPlaces?: number
+
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean
+
+  @IsOptional()
+  @IsBoolean()
+  isBaseCurrency?: boolean
+
+  @IsOptional()
+  @IsUUID()
+  countryId?: string
+}

--- a/backend/src/country-currency/dto/exchange-rate-update.dto.ts
+++ b/backend/src/country-currency/dto/exchange-rate-update.dto.ts
@@ -1,0 +1,10 @@
+import { IsNumber, IsOptional, Min } from "class-validator"
+
+export class ExchangeRateUpdateDto {
+  @IsNumber({ maxDecimalPlaces: 6 })
+  @Min(0)
+  exchangeRateToUSD: number
+
+  @IsOptional()
+  exchangeRateUpdatedAt?: Date
+}

--- a/backend/src/country-currency/dto/update-country.dto.ts
+++ b/backend/src/country-currency/dto/update-country.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from "@nestjs/mapped-types"
+import { CreateCountryDto } from "./create-country.dto"
+
+export class UpdateCountryDto extends PartialType(CreateCountryDto) {}

--- a/backend/src/country-currency/dto/update-currency.dto.ts
+++ b/backend/src/country-currency/dto/update-currency.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from "@nestjs/mapped-types"
+import { CreateCurrencyDto } from "./create-currency.dto"
+
+export class UpdateCurrencyDto extends PartialType(CreateCurrencyDto) {}

--- a/backend/src/country-currency/entities/country.entity.ts
+++ b/backend/src/country-currency/entities/country.entity.ts
@@ -1,0 +1,41 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, OneToMany } from "typeorm"
+import { Currency } from "./currency.entity"
+
+@Entity("countries")
+export class Country {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ unique: true, length: 100 })
+  name: string
+
+  @Column({ unique: true, length: 2 })
+  isoCode2: string // ISO 3166-1 alpha-2 (e.g., 'US', 'GB')
+
+  @Column({ unique: true, length: 3 })
+  isoCode3: string // ISO 3166-1 alpha-3 (e.g., 'USA', 'GBR')
+
+  @Column({ unique: true, length: 3 })
+  numericCode: string // ISO 3166-1 numeric (e.g., '840', '826')
+
+  @Column({ length: 100 })
+  region: string // e.g., 'North America', 'Europe'
+
+  @Column({ length: 100 })
+  subRegion: string // e.g., 'Northern America', 'Western Europe'
+
+  @Column({ default: true })
+  isActive: boolean
+
+  @OneToMany(
+    () => Currency,
+    (currency) => currency.country,
+  )
+  currencies: Currency[]
+
+  @CreateDateColumn()
+  createdAt: Date
+
+  @UpdateDateColumn()
+  updatedAt: Date
+}

--- a/backend/src/country-currency/entities/currency.entity.ts
+++ b/backend/src/country-currency/entities/currency.entity.ts
@@ -1,0 +1,56 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from "typeorm"
+import { Country } from "./country.entity"
+
+@Entity("currencies")
+export class Currency {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ unique: true, length: 3 })
+  code: string // ISO 4217 currency code (e.g., 'USD', 'EUR')
+
+  @Column({ length: 100 })
+  name: string // e.g., 'US Dollar', 'Euro'
+
+  @Column({ length: 10 })
+  symbol: string // e.g., '$', '€', '£'
+
+  @Column("decimal", { precision: 15, scale: 6, default: 1.0 })
+  exchangeRateToUSD: number // Exchange rate relative to USD
+
+  @Column({ type: "timestamp", default: () => "CURRENT_TIMESTAMP" })
+  exchangeRateUpdatedAt: Date
+
+  @Column({ default: 2 })
+  decimalPlaces: number // Number of decimal places for this currency
+
+  @Column({ default: true })
+  isActive: boolean
+
+  @Column({ default: false })
+  isBaseCurrency: boolean // Mark if this is the base currency for calculations
+
+  @Column("uuid", { nullable: true })
+  countryId: string
+
+  @ManyToOne(
+    () => Country,
+    (country) => country.currencies,
+  )
+  @JoinColumn({ name: "countryId" })
+  country: Country
+
+  @CreateDateColumn()
+  createdAt: Date
+
+  @UpdateDateColumn()
+  updatedAt: Date
+}


### PR DESCRIPTION
I added the Country & Currency Module to support multi-country and multi-currency operations for global scalability. It introduces two new entities: countries (with ISO codes) and currencies (with exchange rates). Assets and companies can now be linked to a default currency, enabling better localization and financial accuracy. The module includes full CRUD APIs for managing countries and currencies, laying the foundation for consistent internationalization and financial reporting across regions.

closes #213 