### PR TITLE
feat: auth store, React Query setup, login and register pages

### DIFF
--- a/frontend/contrib/app/(auth)/login/page.tsx
+++ b/frontend/contrib/app/(auth)/login/page.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { Suspense } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { useAuthStore } from '@/contrib/store/auth.store';
+
+const schema = z.object({
+  email: z.string().email('Enter a valid email address'),
+  password: z.string().min(1, 'Password is required'),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+function LoginForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { login, isLoading } = useAuthStore();
+
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors },
+  } = useForm<FormValues>({ resolver: zodResolver(schema) });
+
+  const onSubmit = async (values: FormValues) => {
+    try {
+      await login(values);
+      const redirect = searchParams.get('redirect') || '/dashboard';
+      router.push(redirect);
+    } catch (err: unknown) {
+      const message =
+        (err as { response?: { data?: { message?: string } } })?.response?.data?.message ||
+        'Invalid credentials';
+      setError('root', { message });
+    }
+  };
+
+  return (
+    <>
+      <h2 className="text-xl font-semibold text-gray-900 mb-1">Welcome back</h2>
+      <p className="text-sm text-gray-500 mb-6">Sign in to your account to continue</p>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <Input
+          id="email"
+          label="Email address"
+          type="email"
+          placeholder="you@company.com"
+          autoComplete="email"
+          {...register('email')}
+          error={errors.email?.message}
+        />
+
+        <Input
+          id="password"
+          label="Password"
+          type="password"
+          placeholder="••••••••"
+          autoComplete="current-password"
+          {...register('password')}
+          error={errors.password?.message}
+        />
+
+        {errors.root && (
+          <p className="text-sm text-red-500 bg-red-50 border border-red-200 rounded-lg px-3 py-2">
+            {errors.root.message}
+          </p>
+        )}
+
+        <Button type="submit" size="lg" loading={isLoading} className="w-full mt-2">
+          Sign in
+        </Button>
+      </form>
+
+      <p className="text-center text-sm text-gray-500 mt-6">
+        Don&apos;t have an account?{' '}
+        <Link href="/register" className="font-medium text-gray-900 hover:underline">
+          Create one
+        </Link>
+      </p>
+    </>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginForm />
+    </Suspense>
+  );
+}

--- a/frontend/contrib/app/(auth)/register/page.tsx
+++ b/frontend/contrib/app/(auth)/register/page.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { useAuthStore } from '@/contrib/store/auth.store';
+
+const schema = z
+  .object({
+    firstName: z.string().min(1, 'First name is required'),
+    lastName: z.string().min(1, 'Last name is required'),
+    email: z.string().email('Enter a valid email address'),
+    password: z.string().min(8, 'Password must be at least 8 characters'),
+    confirmPassword: z.string().min(1, 'Please confirm your password'),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: 'Passwords do not match',
+    path: ['confirmPassword'],
+  });
+
+type FormValues = z.infer<typeof schema>;
+
+export default function RegisterPage() {
+  const router = useRouter();
+  const { register: registerUser, isLoading } = useAuthStore();
+
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors },
+  } = useForm<FormValues>({ resolver: zodResolver(schema) });
+
+  const onSubmit = async ({ confirmPassword: _, ...values }: FormValues) => {
+    try {
+      await registerUser(values);
+      router.push('/dashboard');
+    } catch (err: unknown) {
+      const message =
+        (err as { response?: { data?: { message?: string } } })?.response?.data?.message ||
+        'Something went wrong. Please try again.';
+      setError('root', { message });
+    }
+  };
+
+  return (
+    <>
+      <h2 className="text-xl font-semibold text-gray-900 mb-1">Create your account</h2>
+      <p className="text-sm text-gray-500 mb-6">Start managing your assets today</p>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <div className="grid grid-cols-2 gap-3">
+          <Input
+            id="firstName"
+            label="First name"
+            placeholder="John"
+            autoComplete="given-name"
+            {...register('firstName')}
+            error={errors.firstName?.message}
+          />
+          <Input
+            id="lastName"
+            label="Last name"
+            placeholder="Doe"
+            autoComplete="family-name"
+            {...register('lastName')}
+            error={errors.lastName?.message}
+          />
+        </div>
+
+        <Input
+          id="email"
+          label="Email address"
+          type="email"
+          placeholder="you@company.com"
+          autoComplete="email"
+          {...register('email')}
+          error={errors.email?.message}
+        />
+
+        <Input
+          id="password"
+          label="Password"
+          type="password"
+          placeholder="Min. 8 characters"
+          autoComplete="new-password"
+          {...register('password')}
+          error={errors.password?.message}
+        />
+
+        <Input
+          id="confirmPassword"
+          label="Confirm password"
+          type="password"
+          placeholder="Re-enter your password"
+          autoComplete="new-password"
+          {...register('confirmPassword')}
+          error={errors.confirmPassword?.message}
+        />
+
+        {errors.root && (
+          <p className="text-sm text-red-500 bg-red-50 border border-red-200 rounded-lg px-3 py-2">
+            {errors.root.message}
+          </p>
+        )}
+
+        <Button type="submit" size="lg" loading={isLoading} className="w-full mt-2">
+          Create account
+        </Button>
+      </form>
+
+      <p className="text-center text-sm text-gray-500 mt-6">
+        Already have an account?{' '}
+        <Link href="/login" className="font-medium text-gray-900 hover:underline">
+          Sign in
+        </Link>
+      </p>
+    </>
+  );
+}

--- a/frontend/contrib/app/providers.tsx
+++ b/frontend/contrib/app/providers.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60_000,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/frontend/contrib/lib/query/hooks.ts
+++ b/frontend/contrib/lib/query/hooks.ts
@@ -1,0 +1,39 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from './queryKeys';
+import type { Asset, AssetListResponse, Department, Category, AppUser, ReportsSummary } from './types';
+import { api } from '@/lib/api';
+
+export function useAssets() {
+  return useQuery<AssetListResponse>({
+    queryKey: queryKeys.assets.all(),
+    queryFn: () => api.get<AssetListResponse>('/assets').then((r) => r.data),
+  });
+}
+
+export function useDepartments() {
+  return useQuery<Department[]>({
+    queryKey: queryKeys.departments.all(),
+    queryFn: () => api.get<Department[]>('/departments').then((r) => r.data),
+  });
+}
+
+export function useCategories() {
+  return useQuery<Category[]>({
+    queryKey: queryKeys.categories.all(),
+    queryFn: () => api.get<Category[]>('/categories').then((r) => r.data),
+  });
+}
+
+export function useUsers() {
+  return useQuery<AppUser[]>({
+    queryKey: queryKeys.users.all(),
+    queryFn: () => api.get<AppUser[]>('/users').then((r) => r.data),
+  });
+}
+
+export function useReportsSummary() {
+  return useQuery<ReportsSummary>({
+    queryKey: queryKeys.reports.summary(),
+    queryFn: () => api.get<ReportsSummary>('/reports/summary').then((r) => r.data),
+  });
+}

--- a/frontend/contrib/lib/query/queryKeys.ts
+++ b/frontend/contrib/lib/query/queryKeys.ts
@@ -1,0 +1,18 @@
+export const queryKeys = {
+  assets: {
+    all: () => ['assets'] as const,
+    detail: (id: string) => ['assets', 'detail', id] as const,
+  },
+  departments: {
+    all: () => ['departments'] as const,
+  },
+  categories: {
+    all: () => ['categories'] as const,
+  },
+  users: {
+    all: () => ['users'] as const,
+  },
+  reports: {
+    summary: () => ['reports', 'summary'] as const,
+  },
+} as const;

--- a/frontend/contrib/lib/query/types.ts
+++ b/frontend/contrib/lib/query/types.ts
@@ -1,0 +1,59 @@
+export interface AuthUser {
+  id: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  role: string;
+}
+
+export interface Asset {
+  id: string;
+  assetId: string;
+  name: string;
+  description: string | null;
+  status: string;
+  condition: string;
+  location: string | null;
+  createdAt: string;
+  updatedAt: string;
+  category: { id: string; name: string };
+  department: { id: string; name: string };
+}
+
+export interface Department {
+  id: string;
+  name: string;
+  description?: string | null;
+  assetCount: number;
+}
+
+export interface Category {
+  id: string;
+  name: string;
+  description?: string | null;
+  assetCount: number;
+}
+
+export interface AppUser {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  role: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ReportsSummary {
+  total: number;
+  byStatus: Record<string, number>;
+  byCategory: { name: string; count: number }[];
+  byDepartment: { name: string; count: number }[];
+}
+
+export interface AssetListResponse {
+  data: Asset[];
+  total: number;
+  page: number;
+  limit: number;
+}

--- a/frontend/contrib/store/auth.store.ts
+++ b/frontend/contrib/store/auth.store.ts
@@ -1,0 +1,83 @@
+import { create } from 'zustand';
+import { authApi, AuthUser, LoginPayload, RegisterPayload } from '@/lib/auth-api';
+
+function setAuthCookie(token: string) {
+  document.cookie = `auth-token=${token}; path=/; max-age=${15 * 60}; SameSite=Lax`;
+}
+
+function clearAuthCookie() {
+  document.cookie = 'auth-token=; path=/; max-age=0';
+}
+
+interface AuthState {
+  user: AuthUser | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  login: (payload: LoginPayload) => Promise<void>;
+  register: (payload: RegisterPayload) => Promise<void>;
+  logout: () => Promise<void>;
+  loadUser: () => Promise<void>;
+  setUser: (user: AuthUser | null) => void;
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  user: null,
+  isAuthenticated: false,
+  isLoading: false,
+
+  setUser: (user) => set({ user, isAuthenticated: !!user }),
+
+  login: async (payload) => {
+    set({ isLoading: true });
+    try {
+      const data = await authApi.login(payload);
+      localStorage.setItem('accessToken', data.accessToken);
+      localStorage.setItem('refreshToken', data.refreshToken);
+      setAuthCookie(data.accessToken);
+      set({ user: data.user, isAuthenticated: true });
+    } finally {
+      set({ isLoading: false });
+    }
+  },
+
+  register: async (payload) => {
+    set({ isLoading: true });
+    try {
+      const data = await authApi.register(payload);
+      localStorage.setItem('accessToken', data.accessToken);
+      localStorage.setItem('refreshToken', data.refreshToken);
+      setAuthCookie(data.accessToken);
+      set({ user: data.user, isAuthenticated: true });
+    } finally {
+      set({ isLoading: false });
+    }
+  },
+
+  logout: async () => {
+    try {
+      await authApi.logout();
+    } finally {
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
+      clearAuthCookie();
+      set({ user: null, isAuthenticated: false });
+    }
+  },
+
+  loadUser: async () => {
+    const token = localStorage.getItem('accessToken');
+    if (!token) return;
+    set({ isLoading: true });
+    try {
+      const user = await authApi.me();
+      set({ user, isAuthenticated: true });
+    } catch {
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
+      clearAuthCookie();
+      set({ user: null, isAuthenticated: false });
+    } finally {
+      set({ isLoading: false });
+    }
+  },
+}));


### PR DESCRIPTION
Closes #614,
Closes #615,
Closes #616, 
Closes #617

- Zustand auth store with `login`, `register`, `logout`, `loadUser`, `setUser`; stores tokens in localStorage and sets `auth-token` cookie
- React Query provider (`staleTime: 60_000`, `refetchOnWindowFocus: false`), query key factory, API response types, and `useAssets`/`useDepartments`/`useCategories` hooks
- Login page with React Hook Form + Zod, inline errors, loading state, error banner, redirect to `/dashboard`
- Register page with 5 fields including `confirmPassword` with passwords-match validation, same UX pattern