### PR TITLE
feat: implement sidebar, topbar, and dashboard page (FE-13–16)

### DIFF
--- a/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/page.tsx
@@ -2,28 +2,50 @@
 
 import Link from 'next/link';
 import { format } from 'date-fns';
+import { Package, CheckCircle2, UserCheck, Wrench } from 'lucide-react';
 import { useAuthStore } from '@/store/auth.store';
-import { useAssets } from '@/lib/query/hooks/useAssets';
+import { useReportsSummary } from '@/lib/query/hooks/useReports';
 import { StatusBadge } from '@/components/assets/status-badge';
 import { AssetStatus } from '@/lib/query/types/asset';
 
+const statCards = [
+  { label: 'Total Assets',    key: 'total',       icon: Package,      status: null },
+  { label: 'Active',          key: 'active',      icon: CheckCircle2, status: AssetStatus.ACTIVE },
+  { label: 'Assigned',        key: 'assigned',    icon: UserCheck,    status: AssetStatus.ASSIGNED },
+  { label: 'In Maintenance',  key: 'maintenance', icon: Wrench,       status: AssetStatus.MAINTENANCE },
+] as const;
+
+function StatSkeleton() {
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 p-5 animate-pulse">
+      <div className="h-4 w-24 bg-gray-200 rounded mb-3" />
+      <div className="h-8 w-16 bg-gray-200 rounded" />
+    </div>
+  );
+}
+
+function RowSkeleton() {
+  return (
+    <tr className="animate-pulse">
+      {[1, 2, 3, 4, 5].map((i) => (
+        <td key={i} className="px-4 py-3">
+          <div className="h-4 bg-gray-200 rounded w-3/4" />
+        </td>
+      ))}
+    </tr>
+  );
+}
+
 export default function DashboardPage() {
   const user = useAuthStore((s) => s.user);
-  const { data: allAssets } = useAssets({ limit: 5 });
-  const { data: activeAssets } = useAssets({ status: AssetStatus.ACTIVE, limit: 1 });
-  const { data: assignedAssets } = useAssets({ status: AssetStatus.ASSIGNED, limit: 1 });
+  const { data, isLoading, isError } = useReportsSummary();
 
-  const total = allAssets?.total ?? 0;
-  const active = activeAssets?.total ?? 0;
-  const assigned = assignedAssets?.total ?? 0;
-  const recent = allAssets?.data ?? [];
-
-  const stats = [
-    { label: 'Total Assets', value: total },
-    { label: 'Active', value: active },
-    { label: 'Assigned', value: assigned },
-    { label: 'In Maintenance', value: total - active - assigned },
-  ];
+  const counts = {
+    total:       data?.total ?? 0,
+    active:      data?.byStatus?.[AssetStatus.ACTIVE] ?? 0,
+    assigned:    data?.byStatus?.[AssetStatus.ASSIGNED] ?? 0,
+    maintenance: data?.byStatus?.[AssetStatus.MAINTENANCE] ?? 0,
+  };
 
   return (
     <div>
@@ -35,48 +57,82 @@ export default function DashboardPage() {
       </div>
 
       {/* Stat cards */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
-        {stats.map(({ label, value }) => (
-          <div key={label} className="bg-white rounded-xl border border-gray-200 p-5">
-            <p className="text-sm text-gray-500">{label}</p>
-            <p className="text-3xl font-bold text-gray-900 mt-1">{value}</p>
-          </div>
-        ))}
-      </div>
+      {isError ? (
+        <div className="bg-red-50 border border-red-200 rounded-xl p-5 mb-6 text-sm text-red-600">
+          Failed to load summary data. Please try refreshing the page.
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+          {isLoading
+            ? statCards.map((s) => <StatSkeleton key={s.key} />)
+            : statCards.map(({ label, key, icon: Icon, status }) => (
+                <Link
+                  key={key}
+                  href={status ? `/assets?status=${status}` : '/assets'}
+                  className="bg-white rounded-xl border border-gray-200 p-5 hover:border-gray-300 transition-colors"
+                >
+                  <div className="flex items-center justify-between mb-2">
+                    <p className="text-sm text-gray-500">{label}</p>
+                    <Icon size={18} className="text-gray-400" />
+                  </div>
+                  <p className="text-3xl font-bold text-gray-900">{counts[key]}</p>
+                </Link>
+              ))}
+        </div>
+      )}
 
-      {/* Recent assets */}
-      <div className="bg-white rounded-xl border border-gray-200 p-5">
-        <div className="flex items-center justify-between mb-4">
+      {/* Recent assets table */}
+      <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+        <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100">
           <h2 className="text-sm font-semibold text-gray-900">Recent Assets</h2>
           <Link href="/assets" className="text-xs text-gray-500 hover:text-gray-900 hover:underline">
-            View all
+            View all assets
           </Link>
         </div>
 
-        {recent.length === 0 ? (
-          <p className="text-sm text-gray-400 text-center py-8">
-            No assets yet.{' '}
-            <Link href="/assets" className="text-gray-900 underline">Register your first asset</Link>
-          </p>
-        ) : (
-          <div className="space-y-3">
-            {recent.map((asset) => (
-              <Link
-                key={asset.id}
-                href={`/assets/${asset.id}`}
-                className="flex items-center justify-between py-2 border-b border-gray-100 last:border-0 hover:bg-gray-50 -mx-2 px-2 rounded-lg transition-colors"
-              >
-                <div>
-                  <p className="text-sm font-medium text-gray-900">{asset.name}</p>
-                  <p className="text-xs text-gray-400 mt-0.5">
-                    {asset.assetId} · {asset.department?.name} · {format(new Date(asset.createdAt), 'MMM d')}
-                  </p>
-                </div>
-                <StatusBadge status={asset.status} />
-              </Link>
-            ))}
-          </div>
-        )}
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-100 text-xs text-gray-400 uppercase tracking-wide">
+                <th className="px-4 py-3 text-left font-medium">Name</th>
+                <th className="px-4 py-3 text-left font-medium">Asset ID</th>
+                <th className="px-4 py-3 text-left font-medium">Status</th>
+                <th className="px-4 py-3 text-left font-medium">Department</th>
+                <th className="px-4 py-3 text-left font-medium">Created</th>
+              </tr>
+            </thead>
+            <tbody>
+              {isLoading ? (
+                Array.from({ length: 5 }).map((_, i) => <RowSkeleton key={i} />)
+              ) : !data?.recent?.length ? (
+                <tr>
+                  <td colSpan={5} className="px-4 py-10 text-center text-sm text-gray-400">
+                    No assets yet.{' '}
+                    <Link href="/assets" className="text-gray-900 underline">
+                      Register your first asset
+                    </Link>
+                  </td>
+                </tr>
+              ) : (
+                data.recent.map((asset) => (
+                  <tr
+                    key={asset.id}
+                    className="border-b border-gray-100 last:border-0 hover:bg-gray-50 cursor-pointer"
+                    onClick={() => window.location.href = `/assets/${asset.id}`}
+                  >
+                    <td className="px-4 py-3 font-medium text-gray-900">{asset.name}</td>
+                    <td className="px-4 py-3 text-gray-500">{asset.assetId}</td>
+                    <td className="px-4 py-3"><StatusBadge status={asset.status} /></td>
+                    <td className="px-4 py-3 text-gray-500">{asset.department?.name ?? '—'}</td>
+                    <td className="px-4 py-3 text-gray-500">
+                      {format(new Date(asset.createdAt), 'MMM d, yyyy')}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   );

--- a/frontend/app/(dashboard)/layout.tsx
+++ b/frontend/app/(dashboard)/layout.tsx
@@ -1,4 +1,6 @@
-// frontend/app/(dashboard)/layout.tsx
+"use client";
+
+import { useState } from "react";
 import { Sidebar } from "@/components/layout/sidebar";
 import { Topbar } from "@/components/layout/topbar";
 
@@ -7,11 +9,13 @@ export default function DashboardLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
   return (
     <div className="min-h-screen bg-gray-50">
-      <Sidebar />
-      <Topbar />
-      <main className="ml-60 pt-14 min-h-screen">
+      <Sidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+      <Topbar onMenuClick={() => setSidebarOpen(true)} />
+      <main className="lg:ml-60 pt-14 min-h-screen">
         <div className="p-6">{children}</div>
       </main>
     </div>

--- a/frontend/components/layout/sidebar.tsx
+++ b/frontend/components/layout/sidebar.tsx
@@ -1,8 +1,7 @@
-// frontend/components/layout/sidebar.tsx
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { clsx } from "clsx";
 import {
   LayoutDashboard,
@@ -11,7 +10,10 @@ import {
   Building2,
   BarChart3,
   Settings,
+  LogOut,
+  X,
 } from "lucide-react";
+import { useAuthStore } from "@/store/auth.store";
 
 const navItems = [
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
@@ -21,68 +23,112 @@ const navItems = [
   { href: "/reports", label: "Reports", icon: BarChart3 },
 ];
 
-export function Sidebar() {
+interface SidebarProps {
+  open?: boolean;
+  onClose?: () => void;
+}
+
+export function Sidebar({ open, onClose }: SidebarProps) {
   const pathname = usePathname();
+  const router = useRouter();
+  const { logout } = useAuthStore();
+
+  const handleLogout = async () => {
+    await logout();
+    router.push("/login");
+  };
 
   return (
-    <aside className="fixed left-0 top-0 h-full w-60 bg-white border-r border-gray-200 flex flex-col z-30">
-      {/* Logo */}
-      <div className="flex items-center gap-2.5 px-5 py-5 border-b border-gray-100">
-        <div className="flex items-center justify-center w-8 h-8 rounded-lg bg-gray-900">
-          <svg
-            className="w-4 h-4 text-white"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"
-            />
-          </svg>
-        </div>
-        <span className="font-semibold text-gray-900 text-sm">AssetsUp</span>
-      </div>
+    <>
+      {/* Mobile overlay */}
+      {open && (
+        <div
+          className="fixed inset-0 bg-black/40 z-20 lg:hidden"
+          onClick={onClose}
+        />
+      )}
 
-      {/* Navigation */}
-      <nav className="flex-1 px-3 py-4 space-y-0.5 overflow-y-auto">
-        {navItems.map(({ href, label, icon: Icon }) => {
-          const active = pathname === href || pathname.startsWith(`${href}/`);
-          return (
-            <Link
-              key={href}
-              href={href}
-              className={clsx(
-                "flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors",
-                active
-                  ? "bg-gray-100 text-gray-900"
-                  : "text-gray-500 hover:text-gray-900 hover:bg-gray-50",
-              )}
-            >
-              <Icon size={17} />
-              {label}
-            </Link>
-          );
-        })}
-      </nav>
-
-      {/* Settings at bottom */}
-      <div className="px-3 py-4 border-t border-gray-100">
-        <Link
-          href="/settings"
-          className={clsx(
-            "flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors",
-            pathname.startsWith("/settings")
-              ? "bg-gray-100 text-gray-900"
-              : "text-gray-500 hover:text-gray-900 hover:bg-gray-50",
+      <aside
+        className={clsx(
+          "fixed left-0 top-0 h-full w-60 bg-white border-r border-gray-200 flex flex-col z-30 transition-transform duration-200",
+          "lg:translate-x-0",
+          open ? "translate-x-0" : "-translate-x-full lg:translate-x-0",
+        )}
+      >
+        {/* Logo */}
+        <div className="flex items-center justify-between px-5 py-5 border-b border-gray-100">
+          <div className="flex items-center gap-2.5">
+            <div className="flex items-center justify-center w-8 h-8 rounded-lg bg-gray-900">
+              <svg
+                className="w-4 h-4 text-white"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"
+                />
+              </svg>
+            </div>
+            <span className="font-semibold text-gray-900 text-sm">AssetsUp</span>
+          </div>
+          {onClose && (
+            <button onClick={onClose} className="lg:hidden text-gray-400 hover:text-gray-600">
+              <X size={18} />
+            </button>
           )}
-        >
-          <Settings size={17} />
-          Settings
-        </Link>
-      </div>
-    </aside>
+        </div>
+
+        {/* Navigation */}
+        <nav className="flex-1 px-3 py-4 space-y-0.5 overflow-y-auto">
+          {navItems.map(({ href, label, icon: Icon }) => {
+            const active = pathname === href || pathname.startsWith(`${href}/`);
+            return (
+              <Link
+                key={href}
+                href={href}
+                onClick={onClose}
+                className={clsx(
+                  "flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors",
+                  active
+                    ? "bg-gray-100 text-gray-900"
+                    : "text-gray-500 hover:text-gray-900 hover:bg-gray-50",
+                )}
+              >
+                <Icon size={17} />
+                {label}
+              </Link>
+            );
+          })}
+        </nav>
+
+        {/* Bottom: Settings + Logout */}
+        <div className="px-3 py-4 border-t border-gray-100 space-y-0.5">
+          <Link
+            href="/settings"
+            onClick={onClose}
+            className={clsx(
+              "flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors",
+              pathname.startsWith("/settings")
+                ? "bg-gray-100 text-gray-900"
+                : "text-gray-500 hover:text-gray-900 hover:bg-gray-50",
+            )}
+          >
+            <Settings size={17} />
+            Settings
+          </Link>
+          <button
+            onClick={handleLogout}
+            className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium text-gray-500 hover:text-gray-900 hover:bg-gray-50 transition-colors"
+          >
+            <LogOut size={17} />
+            Logout
+          </button>
+        </div>
+      </aside>
+    </>
   );
 }

--- a/frontend/components/layout/topbar.tsx
+++ b/frontend/components/layout/topbar.tsx
@@ -1,62 +1,114 @@
-// frontend/components/layout/topbar.tsx
 "use client";
 
-import { useRouter } from "next/navigation";
-import { LogOut, User } from "lucide-react";
+import { useRouter, usePathname } from "next/navigation";
+import { useState, useRef, useEffect } from "react";
+import { Menu, User, ChevronDown } from "lucide-react";
 import { useAuthStore } from "@/store/auth.store";
 
-export function Topbar() {
+const pageTitles: Record<string, string> = {
+  "/dashboard": "Dashboard",
+  "/assets": "Assets",
+  "/users": "Users",
+  "/departments": "Organisation",
+  "/reports": "Reports",
+  "/settings": "Settings",
+};
+
+function getPageTitle(pathname: string): string {
+  for (const [prefix, title] of Object.entries(pageTitles)) {
+    if (pathname === prefix || pathname.startsWith(`${prefix}/`)) return title;
+  }
+  return "Dashboard";
+}
+
+interface TopbarProps {
+  onMenuClick?: () => void;
+}
+
+export function Topbar({ onMenuClick }: TopbarProps) {
   const router = useRouter();
+  const pathname = usePathname();
   const { user, logout } = useAuthStore();
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
   const handleLogout = async () => {
+    setDropdownOpen(false);
     await logout();
     router.push("/login");
   };
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setDropdownOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, []);
 
   const initials = user
     ? `${user.firstName[0]}${user.lastName[0]}`.toUpperCase()
     : "?";
 
   return (
-    <header className="fixed top-0 left-60 right-0 h-14 bg-white border-b border-gray-200 flex items-center justify-between px-6 z-20">
-      <div />
-
+    <header className="fixed top-0 left-0 lg:left-60 right-0 h-14 bg-white border-b border-gray-200 flex items-center justify-between px-4 lg:px-6 z-20">
+      {/* Left: hamburger (mobile) + page title */}
       <div className="flex items-center gap-3">
-        {/* User info */}
-        <div className="flex items-center gap-2.5">
+        <button
+          onClick={onMenuClick}
+          className="lg:hidden text-gray-500 hover:text-gray-900"
+          aria-label="Open menu"
+        >
+          <Menu size={20} />
+        </button>
+        <h1 className="text-sm font-semibold text-gray-900">
+          {getPageTitle(pathname)}
+        </h1>
+      </div>
+
+      {/* Right: user dropdown */}
+      <div className="relative" ref={dropdownRef}>
+        <button
+          onClick={() => setDropdownOpen((v) => !v)}
+          className="flex items-center gap-2.5 hover:opacity-80 transition-opacity"
+        >
           <div className="w-8 h-8 rounded-full bg-gray-200 flex items-center justify-center">
             {user ? (
-              <span className="text-xs font-semibold text-gray-700">
-                {initials}
-              </span>
+              <span className="text-xs font-semibold text-gray-700">{initials}</span>
             ) : (
               <User size={15} className="text-gray-500" />
             )}
           </div>
           {user && (
-            <div className="hidden sm:block">
+            <div className="hidden sm:block text-left">
               <p className="text-sm font-medium text-gray-900 leading-none">
                 {user.firstName} {user.lastName}
               </p>
-              <p className="text-xs text-gray-400 mt-0.5 capitalize">
-                {user.role}
-              </p>
+              <p className="text-xs text-gray-400 mt-0.5 capitalize">{user.role}</p>
             </div>
           )}
-        </div>
-
-        {/* Divider */}
-        <div className="h-5 w-px bg-gray-200" />
-
-        {/* Logout */}
-        <button
-          onClick={handleLogout}
-          className="flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-900 transition-colors"
-        >
-          <LogOut size={16} />
-          <span className="hidden sm:block">Logout</span>
+          <ChevronDown size={14} className="text-gray-400 hidden sm:block" />
         </button>
+
+        {dropdownOpen && (
+          <div className="absolute right-0 mt-2 w-44 bg-white border border-gray-200 rounded-lg shadow-md py-1 z-50">
+            <button
+              onClick={() => { setDropdownOpen(false); router.push("/settings"); }}
+              className="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+            >
+              View Profile
+            </button>
+            <button
+              onClick={handleLogout}
+              className="w-full text-left px-4 py-2 text-sm text-red-600 hover:bg-gray-50"
+            >
+              Logout
+            </button>
+          </div>
+        )}
       </div>
     </header>
   );


### PR DESCRIPTION
Closes #618,
Closes #619, 
Closes #620, 
Closes #621

**Sidebar (#618)**
- Logout button at bottom
- Mobile slide-in with backdrop overlay and X close button
- `SidebarProps { open, onClose }`

**Topbar (#619)**
- Dynamic page title from pathname
- User dropdown: View Profile → `/settings`, Logout
- Mobile hamburger button

**Dashboard layout**
- Client component wiring `sidebarOpen` state between Topbar and Sidebar
- `ml-60` only on `lg:` breakpoint

**Dashboard stats (#620)**
- `useReportsSummary` for data
- Loading skeleton, error state
- Icons per card (Package, CheckCircle2, UserCheck, Wrench)
- Cards link to `/assets?status=` filter

**Dashboard recent assets (#621)**
- Data from `reports/summary` `recent` field
- Table columns: Name, Asset ID, Status, Department, Created
- Row loading skeleton, empty state
- Rows navigate to `/assets/:id`
- View all assets link