### PR TITLE
feat: assets UI - filter bar, paginated table, create modal (FE-17–20)

### DIFF
--- a/frontend/contrib/app/(dashboard)/assets/page.tsx
+++ b/frontend/contrib/app/(dashboard)/assets/page.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Plus, Eye, Pencil, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { StatusBadge } from "@/components/assets/status-badge";
+import { ConditionBadge } from "@/components/assets/condition-badge";
+import { useAssets, useCreateAsset } from "@/lib/query/hooks/useAssets";
+import { useDeleteAsset } from "@/lib/query/hooks/useAsset";
+import { useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from "@/lib/query/keys";
+import { AssetFilterBar, AssetFilters } from "@/contrib/components/assets/AssetFilterBar";
+import { CreateAssetModal } from "@/contrib/components/assets/CreateAssetModal";
+
+const LIMIT = 20;
+
+function SkeletonRow() {
+  return (
+    <tr className="border-b border-gray-100">
+      {Array.from({ length: 7 }).map((_, i) => (
+        <td key={i} className="px-4 py-3">
+          <div className="h-4 bg-gray-100 rounded animate-pulse" />
+        </td>
+      ))}
+    </tr>
+  );
+}
+
+export default function AssetsContribPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const queryClient = useQueryClient();
+
+  const [page, setPage] = useState(1);
+  const [showModal, setShowModal] = useState(false);
+  const [deleteId, setDeleteId] = useState<string | null>(null);
+  const [editId, setEditId] = useState<string | null>(null);
+
+  const [filters, setFilters] = useState<AssetFilters>({
+    search: searchParams.get("search") ?? "",
+    status: searchParams.get("status") ?? "",
+    condition: searchParams.get("condition") ?? "",
+    departmentId: searchParams.get("departmentId") ?? "",
+    categoryId: searchParams.get("categoryId") ?? "",
+  });
+
+  const { data, isLoading } = useAssets({
+    search: filters.search || undefined,
+    status: filters.status || undefined,
+    condition: filters.condition || undefined,
+    departmentId: filters.departmentId || undefined,
+    categoryId: filters.categoryId || undefined,
+    page,
+    limit: LIMIT,
+  });
+
+  const assets = data?.data ?? [];
+  const total = data?.total ?? 0;
+  const totalPages = Math.ceil(total / LIMIT);
+
+  const deleteAsset = useDeleteAsset(deleteId ?? "");
+
+  const handleDelete = async () => {
+    if (!deleteId) return;
+    await deleteAsset.mutateAsync();
+    // optimistic: already removed from cache by mutation
+    setDeleteId(null);
+  };
+
+  const handleFilterChange = (next: AssetFilters) => {
+    setFilters(next);
+    setPage(1);
+  };
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Assets</h1>
+          <p className="text-sm text-gray-500 mt-1">
+            {total > 0 ? `${total} asset${total !== 1 ? "s" : ""}` : "No assets yet"}
+          </p>
+        </div>
+        <Button onClick={() => setShowModal(true)}>
+          <Plus size={16} className="mr-1.5" />
+          Create Asset
+        </Button>
+      </div>
+
+      {/* Filter Bar */}
+      <AssetFilterBar filters={filters} onChange={handleFilterChange} />
+
+      {/* Table */}
+      <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-200 bg-gray-50">
+                {["Asset ID", "Name", "Category", "Department", "Status", "Condition", "Actions"].map(
+                  (h) => (
+                    <th key={h} className="text-left px-4 py-3 font-medium text-gray-500">
+                      {h}
+                    </th>
+                  )
+                )}
+              </tr>
+            </thead>
+            <tbody>
+              {isLoading ? (
+                Array.from({ length: 5 }).map((_, i) => <SkeletonRow key={i} />)
+              ) : assets.length === 0 ? (
+                <tr>
+                  <td colSpan={7} className="text-center py-12 text-gray-400">
+                    {Object.values(filters).some(Boolean)
+                      ? "No assets match your filters."
+                      : 'No assets yet. Click "Create Asset" to get started.'}
+                  </td>
+                </tr>
+              ) : (
+                assets.map((asset) => (
+                  <tr
+                    key={asset.id}
+                    className="border-b border-gray-100 hover:bg-gray-50 transition-colors"
+                  >
+                    <td className="px-4 py-3 font-mono text-xs text-gray-500">{asset.assetId}</td>
+                    <td className="px-4 py-3 font-medium text-gray-900">{asset.name}</td>
+                    <td className="px-4 py-3 text-gray-600">{asset.category?.name ?? "—"}</td>
+                    <td className="px-4 py-3 text-gray-600">{asset.department?.name ?? "—"}</td>
+                    <td className="px-4 py-3">
+                      <StatusBadge status={asset.status} />
+                    </td>
+                    <td className="px-4 py-3">
+                      <ConditionBadge condition={asset.condition} />
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-2">
+                        <button
+                          onClick={() => router.push(`/assets/${asset.id}`)}
+                          className="text-gray-400 hover:text-gray-700"
+                          title="View"
+                        >
+                          <Eye size={16} />
+                        </button>
+                        <button
+                          onClick={() => setEditId(asset.id)}
+                          className="text-gray-400 hover:text-gray-700"
+                          title="Edit"
+                        >
+                          <Pencil size={16} />
+                        </button>
+                        <button
+                          onClick={() => setDeleteId(asset.id)}
+                          className="text-gray-400 hover:text-red-600"
+                          title="Delete"
+                        >
+                          <Trash2 size={16} />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div className="flex items-center justify-between px-4 py-3 border-t border-gray-200">
+            <p className="text-sm text-gray-500">
+              Page {page} of {totalPages} — {total} total
+            </p>
+            <div className="flex gap-2">
+              <Button variant="outline" size="sm" disabled={page === 1} onClick={() => setPage((p) => p - 1)}>
+                Previous
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page === totalPages}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                Next
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Create Modal */}
+      {showModal && (
+        <CreateAssetModal
+          onClose={() => setShowModal(false)}
+          onSuccess={() => {
+            queryClient.invalidateQueries({ queryKey: queryKeys.assets.all });
+            setShowModal(false);
+          }}
+        />
+      )}
+
+      {/* Edit Modal */}
+      {editId && (
+        <CreateAssetModal
+          assetId={editId}
+          onClose={() => setEditId(null)}
+          onSuccess={() => {
+            queryClient.invalidateQueries({ queryKey: queryKeys.assets.all });
+            setEditId(null);
+          }}
+        />
+      )}
+
+      {/* Delete Confirm */}
+      {deleteId && (
+        <ConfirmDialog
+          title="Delete Asset"
+          message="This action cannot be undone. The asset will be permanently removed."
+          confirmLabel="Delete"
+          loading={deleteAsset.isPending}
+          onConfirm={handleDelete}
+          onCancel={() => setDeleteId(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/contrib/components/assets/AssetFilterBar.tsx
+++ b/frontend/contrib/components/assets/AssetFilterBar.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+import { Search, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useCategories, useDepartmentsList } from "@/lib/query/hooks/useAssets";
+import { AssetStatus, AssetCondition } from "@/lib/query/types/asset";
+
+export interface AssetFilters {
+  search: string;
+  status: string;
+  condition: string;
+  departmentId: string;
+  categoryId: string;
+}
+
+interface Props {
+  filters: AssetFilters;
+  onChange: (filters: AssetFilters) => void;
+}
+
+export function AssetFilterBar({ filters, onChange }: Props) {
+  const { data: categories = [] } = useCategories();
+  const { data: departments = [] } = useDepartmentsList();
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  // Sync filters to URL
+  useEffect(() => {
+    const params = new URLSearchParams(searchParams.toString());
+    (Object.keys(filters) as (keyof AssetFilters)[]).forEach((key) => {
+      if (filters[key]) {
+        params.set(key, filters[key]);
+      } else {
+        params.delete(key);
+      }
+    });
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+  }, [filters]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const set = (key: keyof AssetFilters, value: string) =>
+    onChange({ ...filters, [key]: value });
+
+  const handleSearch = (value: string) => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => set("search", value), 300);
+  };
+
+  const hasFilters = Object.values(filters).some(Boolean);
+
+  return (
+    <div className="flex flex-wrap gap-3 mb-4">
+      {/* Search */}
+      <div className="relative flex-1 min-w-[200px] max-w-sm">
+        <Search
+          size={16}
+          className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+        />
+        <input
+          type="text"
+          placeholder="Search by name, ID, serial..."
+          defaultValue={filters.search}
+          onChange={(e) => handleSearch(e.target.value)}
+          className="w-full pl-9 pr-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-900"
+        />
+      </div>
+
+      {/* Status */}
+      <select
+        value={filters.status}
+        onChange={(e) => set("status", e.target.value)}
+        className="text-sm border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-gray-900 text-gray-700"
+      >
+        <option value="">All Statuses</option>
+        {Object.values(AssetStatus).map((s) => (
+          <option key={s} value={s}>
+            {s.charAt(0) + s.slice(1).toLowerCase()}
+          </option>
+        ))}
+      </select>
+
+      {/* Condition */}
+      <select
+        value={filters.condition}
+        onChange={(e) => set("condition", e.target.value)}
+        className="text-sm border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-gray-900 text-gray-700"
+      >
+        <option value="">All Conditions</option>
+        {Object.values(AssetCondition).map((c) => (
+          <option key={c} value={c}>
+            {c.charAt(0) + c.slice(1).toLowerCase()}
+          </option>
+        ))}
+      </select>
+
+      {/* Department */}
+      <select
+        value={filters.departmentId}
+        onChange={(e) => set("departmentId", e.target.value)}
+        className="text-sm border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-gray-900 text-gray-700"
+      >
+        <option value="">All Departments</option>
+        {departments.map((d) => (
+          <option key={d.id} value={d.id}>
+            {d.name}
+          </option>
+        ))}
+      </select>
+
+      {/* Category */}
+      <select
+        value={filters.categoryId}
+        onChange={(e) => set("categoryId", e.target.value)}
+        className="text-sm border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-gray-900 text-gray-700"
+      >
+        <option value="">All Categories</option>
+        {categories.map((c) => (
+          <option key={c.id} value={c.id}>
+            {c.name}
+          </option>
+        ))}
+      </select>
+
+      {/* Reset */}
+      {hasFilters && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() =>
+            onChange({
+              search: "",
+              status: "",
+              condition: "",
+              departmentId: "",
+              categoryId: "",
+            })
+          }
+        >
+          <X size={14} className="mr-1" />
+          Reset
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/frontend/contrib/components/assets/CreateAssetModal.tsx
+++ b/frontend/contrib/components/assets/CreateAssetModal.tsx
@@ -1,0 +1,295 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useCreateAsset, useCategories, useDepartmentsList } from "@/lib/query/hooks/useAssets";
+import { useUpdateAsset } from "@/lib/query/hooks/useAssets";
+import { AssetCondition } from "@/lib/query/types/asset";
+
+const schema = z.object({
+  // Basic
+  name: z.string().min(1, "Asset name is required"),
+  categoryId: z.string().min(1, "Category is required"),
+  departmentId: z.string().min(1, "Department is required"),
+  serialNumber: z.string().optional(),
+  location: z.string().optional(),
+  condition: z.nativeEnum(AssetCondition).optional(),
+  // Advanced
+  purchaseDate: z.string().optional(),
+  purchasePrice: z.string().optional(),
+  currentValue: z.string().optional(),
+  warrantyExpiration: z.string().optional(),
+  manufacturer: z.string().optional(),
+  model: z.string().optional(),
+  tags: z.string().optional(),
+  description: z.string().optional(),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+interface Props {
+  assetId?: string;
+  onClose: () => void;
+  onSuccess?: () => void;
+}
+
+const TABS = ["Basic Info", "Additional Details"] as const;
+type Tab = (typeof TABS)[number];
+
+const selectClass =
+  "w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900";
+
+export function CreateAssetModal({ assetId, onClose, onSuccess }: Props) {
+  const [tab, setTab] = useState<Tab>("Basic Info");
+  const { data: categories = [] } = useCategories();
+  const { data: departments = [] } = useDepartmentsList();
+  const createAsset = useCreateAsset();
+  const updateAsset = useUpdateAsset(assetId ?? "");
+
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { condition: AssetCondition.NEW },
+  });
+
+  const onSubmit = async (values: FormValues) => {
+    const payload = {
+      name: values.name,
+      categoryId: values.categoryId,
+      departmentId: values.departmentId,
+      serialNumber: values.serialNumber || undefined,
+      location: values.location || undefined,
+      condition: values.condition,
+      purchaseDate: values.purchaseDate || undefined,
+      purchasePrice: values.purchasePrice ? parseFloat(values.purchasePrice) : undefined,
+      currentValue: values.currentValue ? parseFloat(values.currentValue) : undefined,
+      warrantyExpiration: values.warrantyExpiration || undefined,
+      manufacturer: values.manufacturer || undefined,
+      model: values.model || undefined,
+      tags: values.tags ? values.tags.split(",").map((t) => t.trim()).filter(Boolean) : undefined,
+      description: values.description || undefined,
+    };
+
+    try {
+      if (assetId) {
+        await updateAsset.mutateAsync(payload);
+      } else {
+        await createAsset.mutateAsync(payload);
+      }
+      onSuccess?.();
+      onClose();
+    } catch (err: unknown) {
+      const message =
+        (err as { response?: { data?: { message?: string } } })?.response?.data?.message ||
+        "Something went wrong.";
+      setError("root", { message });
+    }
+  };
+
+  const isPending = createAsset.isPending || updateAsset.isPending;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+      <div className="relative bg-white rounded-2xl shadow-xl w-full max-w-xl max-h-[90vh] overflow-y-auto">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 sticky top-0 bg-white">
+          <h2 className="text-base font-semibold text-gray-900">
+            {assetId ? "Edit Asset" : "Create Asset"}
+          </h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+            <X size={20} />
+          </button>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex border-b border-gray-200 px-6">
+          {TABS.map((t) => (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              className={`py-3 px-1 mr-6 text-sm font-medium border-b-2 transition-colors ${
+                tab === t
+                  ? "border-gray-900 text-gray-900"
+                  : "border-transparent text-gray-500 hover:text-gray-700"
+              }`}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="px-6 py-5 space-y-4">
+          {/* ── Basic Info ── */}
+          {tab === "Basic Info" && (
+            <>
+              <Input
+                id="name"
+                label="Asset Name *"
+                placeholder="e.g. MacBook Pro 16&quot;"
+                {...register("name")}
+                error={errors.name?.message}
+              />
+
+              <div className="grid grid-cols-2 gap-3">
+                <div className="flex flex-col gap-1">
+                  <label className="text-sm font-medium text-gray-700">Category *</label>
+                  <select {...register("categoryId")} className={selectClass}>
+                    <option value="">Select category</option>
+                    {categories.map((c) => (
+                      <option key={c.id} value={c.id}>
+                        {c.name}
+                      </option>
+                    ))}
+                  </select>
+                  {errors.categoryId && (
+                    <p className="text-xs text-red-500">{errors.categoryId.message}</p>
+                  )}
+                </div>
+
+                <div className="flex flex-col gap-1">
+                  <label className="text-sm font-medium text-gray-700">Department *</label>
+                  <select {...register("departmentId")} className={selectClass}>
+                    <option value="">Select department</option>
+                    {departments.map((d) => (
+                      <option key={d.id} value={d.id}>
+                        {d.name}
+                      </option>
+                    ))}
+                  </select>
+                  {errors.departmentId && (
+                    <p className="text-xs text-red-500">{errors.departmentId.message}</p>
+                  )}
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <Input
+                  id="serialNumber"
+                  label="Serial Number"
+                  placeholder="SN-12345"
+                  {...register("serialNumber")}
+                />
+                <Input
+                  id="location"
+                  label="Location"
+                  placeholder="Floor 2, Room 204"
+                  {...register("location")}
+                />
+              </div>
+
+              <div className="flex flex-col gap-1">
+                <label className="text-sm font-medium text-gray-700">Condition</label>
+                <select {...register("condition")} className={selectClass}>
+                  {Object.values(AssetCondition).map((c) => (
+                    <option key={c} value={c}>
+                      {c.charAt(0) + c.slice(1).toLowerCase()}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </>
+          )}
+
+          {/* ── Additional Details ── */}
+          {tab === "Additional Details" && (
+            <>
+              <div className="grid grid-cols-2 gap-3">
+                <Input
+                  id="purchaseDate"
+                  label="Purchase Date"
+                  type="date"
+                  {...register("purchaseDate")}
+                />
+                <Input
+                  id="warrantyExpiration"
+                  label="Warranty Expiration"
+                  type="date"
+                  {...register("warrantyExpiration")}
+                />
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <Input
+                  id="purchasePrice"
+                  label="Purchase Price ($)"
+                  type="number"
+                  step="0.01"
+                  placeholder="0.00"
+                  {...register("purchasePrice")}
+                />
+                <Input
+                  id="currentValue"
+                  label="Current Value ($)"
+                  type="number"
+                  step="0.01"
+                  placeholder="0.00"
+                  {...register("currentValue")}
+                />
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <Input
+                  id="manufacturer"
+                  label="Manufacturer"
+                  placeholder="Apple"
+                  {...register("manufacturer")}
+                />
+                <Input
+                  id="model"
+                  label="Model"
+                  placeholder="MacBook Pro"
+                  {...register("model")}
+                />
+              </div>
+
+              <Input
+                id="tags"
+                label="Tags (comma-separated)"
+                placeholder="laptop, engineering, remote"
+                {...register("tags")}
+              />
+
+              <div className="flex flex-col gap-1">
+                <label htmlFor="description" className="text-sm font-medium text-gray-700">
+                  Description
+                </label>
+                <textarea
+                  id="description"
+                  rows={3}
+                  placeholder="Additional details..."
+                  {...register("description")}
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-900 resize-none"
+                />
+              </div>
+            </>
+          )}
+
+          {errors.root && (
+            <p className="text-sm text-red-500 bg-red-50 border border-red-200 rounded-lg px-3 py-2">
+              {errors.root.message}
+            </p>
+          )}
+
+          <div className="flex gap-3 pt-2">
+            <Button type="button" variant="outline" className="flex-1" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" className="flex-1" loading={isPending}>
+              {assetId ? "Save Changes" : "Create Asset"}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #622, 
Closes #623, 
Closes #624, 
Closes #625

## Changes

- **FE-17** `AssetFilterBar`: debounced search, status/condition/department/category dropdowns, URL query param sync, reset button
- **FE-18** Assets page: paginated table with skeleton loading, empty state, view/edit/delete row actions, optimistic delete
- **FE-19 + FE-20** `CreateAssetModal`: two-tab modal — Basic Info (name, category, department, serial, location, condition) and Additional Details (purchase date/price, current value, warranty, manufacturer, model, tags, description)