### PR TITLE
feat: asset detail tabs and contract unit tests

### DIFF
--- a/contracts/contrib/Cargo.toml
+++ b/contracts/contrib/Cargo.toml
@@ -11,3 +11,4 @@ soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+assetsup = { path = "../assetsup" }

--- a/contracts/contrib/src/tests/detokenization.rs
+++ b/contracts/contrib/src/tests/detokenization.rs
@@ -1,0 +1,81 @@
+use assetsup::types::AssetType;
+use assetsup::{AssetUpContract, AssetUpContractClient};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+fn setup(env: &Env) -> AssetUpContractClient<'_> {
+    let admin = Address::generate(env);
+    let id = env.register(AssetUpContract, ());
+    let client = AssetUpContractClient::new(env, &id);
+    env.mock_all_auths();
+    client.initialize(&admin);
+    client
+}
+
+fn tokenize(client: &AssetUpContractClient<'_>, env: &Env, asset_id: u64, tokenizer: &Address) {
+    client.tokenize_asset(
+        &asset_id,
+        &String::from_str(env, "DTK"),
+        &1_000_000i128,
+        &6u32,
+        &100i128,
+        tokenizer,
+        &String::from_str(env, "Detokenize Token"),
+        &String::from_str(env, "Detokenization test asset"),
+        &AssetType::Physical,
+    );
+}
+
+#[test]
+fn test_execute_detokenization_end_to_end() {
+    let env = Env::default();
+    let client = setup(&env);
+    let proposer = Address::generate(&env);
+
+    env.mock_all_auths();
+    tokenize(&client, &env, 1, &proposer);
+
+    // Propose detokenization
+    let proposal_id = client.propose_detokenization(&1u64, &proposer).unwrap();
+    assert!(client.is_detokenization_active(&1u64).unwrap());
+
+    // proposer holds 100% — cast vote so proposal passes
+    client.cast_vote(&1u64, &proposal_id, &proposer);
+    assert!(client.proposal_passed(&1u64, &proposal_id).unwrap());
+
+    // Execute detokenization
+    client.execute_detokenization(&1u64, &proposal_id);
+
+    // Asset should no longer be tokenized
+    assert!(!client.is_detokenization_active(&1u64).unwrap());
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #28)")]
+fn test_execute_detokenization_without_votes_panics() {
+    let env = Env::default();
+    let client = setup(&env);
+    let proposer = Address::generate(&env);
+
+    env.mock_all_auths();
+    tokenize(&client, &env, 1, &proposer);
+
+    let proposal_id = client.propose_detokenization(&1u64, &proposer).unwrap();
+
+    // No votes cast — should panic with DetokenizationNotApproved (#28)
+    client.execute_detokenization(&1u64, &proposal_id);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #29)")]
+fn test_propose_detokenization_duplicate_panics() {
+    let env = Env::default();
+    let client = setup(&env);
+    let proposer = Address::generate(&env);
+
+    env.mock_all_auths();
+    tokenize(&client, &env, 1, &proposer);
+
+    client.propose_detokenization(&1u64, &proposer);
+    // Second proposal on same active asset should panic with DetokenizationAlreadyProposed (#29)
+    client.propose_detokenization(&1u64, &proposer);
+}

--- a/contracts/contrib/src/tests/dividends.rs
+++ b/contracts/contrib/src/tests/dividends.rs
@@ -1,0 +1,86 @@
+use assetsup::types::AssetType;
+use assetsup::{AssetUpContract, AssetUpContractClient};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+fn setup(env: &Env) -> AssetUpContractClient<'_> {
+    let admin = Address::generate(env);
+    let id = env.register(AssetUpContract, ());
+    let client = AssetUpContractClient::new(env, &id);
+    env.mock_all_auths();
+    client.initialize(&admin);
+    client
+}
+
+fn tokenize(client: &AssetUpContractClient<'_>, env: &Env, asset_id: u64, tokenizer: &Address) {
+    client.tokenize_asset(
+        &asset_id,
+        &String::from_str(env, "DIV"),
+        &1_000_000i128,
+        &6u32,
+        &100i128,
+        tokenizer,
+        &String::from_str(env, "Dividend Token"),
+        &String::from_str(env, "Dividend test asset"),
+        &AssetType::Physical,
+    );
+}
+
+#[test]
+fn test_distribute_and_claim_dividends_single_holder() {
+    let env = Env::default();
+    let client = setup(&env);
+    let holder = Address::generate(&env);
+
+    env.mock_all_auths();
+    tokenize(&client, &env, 1, &holder);
+    client.enable_revenue_sharing(&1u64);
+
+    client.distribute_dividends(&1u64, &10_000i128);
+
+    let unclaimed = client.get_unclaimed_dividends(&1u64, &holder).unwrap();
+    assert_eq!(unclaimed, 10_000);
+
+    let claimed = client.claim_dividends(&1u64, &holder).unwrap();
+    assert_eq!(claimed, 10_000);
+
+    // After claiming, unclaimed should be zero
+    assert_eq!(client.get_unclaimed_dividends(&1u64, &holder).unwrap(), 0);
+}
+
+#[test]
+fn test_distribute_dividends_proportional_multiple_holders() {
+    let env = Env::default();
+    let client = setup(&env);
+    let holder_a = Address::generate(&env);
+    let holder_b = Address::generate(&env);
+
+    env.mock_all_auths();
+    tokenize(&client, &env, 1, &holder_a); // holder_a gets 1_000_000 tokens
+    client.enable_revenue_sharing(&1u64);
+
+    // Transfer 250_000 (25%) to holder_b; holder_a retains 750_000 (75%)
+    client.transfer_tokens(&1u64, &holder_a, &holder_b, &250_000i128);
+
+    client.distribute_dividends(&1u64, &1_000_000i128);
+
+    let a_unclaimed = client.get_unclaimed_dividends(&1u64, &holder_a).unwrap();
+    let b_unclaimed = client.get_unclaimed_dividends(&1u64, &holder_b).unwrap();
+
+    assert_eq!(a_unclaimed, 750_000); // 75%
+    assert_eq!(b_unclaimed, 250_000); // 25%
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #26)")]
+fn test_claim_dividends_nothing_to_claim() {
+    let env = Env::default();
+    let client = setup(&env);
+    let holder = Address::generate(&env);
+
+    env.mock_all_auths();
+    tokenize(&client, &env, 1, &holder);
+    client.enable_revenue_sharing(&1u64);
+
+    // No distribution happened — should panic with NoDividendsToClaim (#26)
+    client.claim_dividends(&1u64, &holder);
+}

--- a/contracts/contrib/src/tests/mod.rs
+++ b/contracts/contrib/src/tests/mod.rs
@@ -1,3 +1,8 @@
+
+mod tokenization;
+mod voting;
+mod dividends;
+mod detokenization;
 use crate::{Asset, AssetStatus, ContribContract, ContribContractClient};
 use soroban_sdk::{testutils::Address as _, testutils::Events as _, Address, BytesN, Env, String};
 

--- a/contracts/contrib/src/tests/tokenization.rs
+++ b/contracts/contrib/src/tests/tokenization.rs
@@ -1,0 +1,105 @@
+use assetsup::types::AssetType;
+use assetsup::{AssetUpContract, AssetUpContractClient};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+fn setup(env: &Env) -> (AssetUpContractClient<'_>, Address) {
+    let admin = Address::generate(env);
+    let id = env.register(AssetUpContract, ());
+    let client = AssetUpContractClient::new(env, &id);
+    env.mock_all_auths();
+    client.initialize(&admin);
+    (client, admin)
+}
+
+fn tokenize(client: &AssetUpContractClient<'_>, env: &Env, asset_id: u64, tokenizer: &Address) {
+    client.tokenize_asset(
+        &asset_id,
+        &String::from_str(env, "TST"),
+        &1_000_000i128,
+        &6u32,
+        &100i128,
+        tokenizer,
+        &String::from_str(env, "Test Token"),
+        &String::from_str(env, "A tokenized asset"),
+        &AssetType::Physical,
+    );
+}
+
+#[test]
+fn test_tokenize_asset_success() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+    let tokenizer = Address::generate(&env);
+
+    env.mock_all_auths();
+    tokenize(&client, &env, 1, &tokenizer);
+
+    let asset = client.get_tokenized_asset(&1u64);
+    assert_eq!(asset.asset_id, 1);
+    assert_eq!(asset.total_supply, 1_000_000);
+    assert_eq!(asset.tokenizer, tokenizer);
+    assert_eq!(asset.tokens_in_circulation, 1_000_000);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #10)")]
+fn test_tokenize_asset_already_tokenized() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+    let tokenizer = Address::generate(&env);
+
+    env.mock_all_auths();
+    tokenize(&client, &env, 1, &tokenizer);
+    // second call must panic with AssetAlreadyTokenized (#10)
+    tokenize(&client, &env, 1, &tokenizer);
+}
+
+#[test]
+fn test_transfer_tokens_success() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+
+    env.mock_all_auths();
+    tokenize(&client, &env, 1, &from);
+
+    client.transfer_tokens(&1u64, &from, &to, &400_000i128);
+
+    assert_eq!(client.get_token_balance(&1u64, &from).unwrap(), 600_000);
+    assert_eq!(client.get_token_balance(&1u64, &to).unwrap(), 400_000);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #14)")]
+fn test_transfer_tokens_insufficient_balance() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+
+    env.mock_all_auths();
+    tokenize(&client, &env, 1, &from);
+
+    // Try to transfer more than balance — should panic with InsufficientBalance (#14)
+    client.transfer_tokens(&1u64, &from, &to, &2_000_000i128);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #17)")]
+fn test_transfer_tokens_blacklisted_recipient() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+    let from = Address::generate(&env);
+    let blocked = Address::generate(&env);
+    let allowed = Address::generate(&env);
+
+    env.mock_all_auths();
+    tokenize(&client, &env, 1, &from);
+
+    // Add only `allowed` to whitelist — `blocked` is not listed
+    client.add_to_whitelist(&1u64, &allowed);
+
+    // Transfer to non-whitelisted address should panic with TransferRestrictionFailed (#17)
+    client.transfer_tokens(&1u64, &from, &blocked, &100_000i128);
+}

--- a/contracts/contrib/src/tests/voting.rs
+++ b/contracts/contrib/src/tests/voting.rs
@@ -1,0 +1,100 @@
+use assetsup::types::AssetType;
+use assetsup::{AssetUpContract, AssetUpContractClient};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+fn setup(env: &Env) -> AssetUpContractClient<'_> {
+    let admin = Address::generate(env);
+    let id = env.register(AssetUpContract, ());
+    let client = AssetUpContractClient::new(env, &id);
+    env.mock_all_auths();
+    client.initialize(&admin);
+    client
+}
+
+fn tokenize(client: &AssetUpContractClient<'_>, env: &Env, asset_id: u64, tokenizer: &Address) {
+    client.tokenize_asset(
+        &asset_id,
+        &String::from_str(env, "VOT"),
+        &1_000_000i128,
+        &6u32,
+        &100i128,
+        tokenizer,
+        &String::from_str(env, "Vote Token"),
+        &String::from_str(env, "Voting test asset"),
+        &AssetType::Physical,
+    );
+}
+
+#[test]
+fn test_cast_vote_success() {
+    let env = Env::default();
+    let client = setup(&env);
+    let voter = Address::generate(&env);
+
+    env.mock_all_auths();
+    tokenize(&client, &env, 1, &voter);
+
+    client.cast_vote(&1u64, &1u64, &voter);
+
+    assert!(client.has_voted(&1u64, &1u64, &voter).unwrap());
+    assert_eq!(client.get_vote_tally(&1u64, &1u64).unwrap(), 1_000_000);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #22)")]
+fn test_cast_vote_double_vote_panics() {
+    let env = Env::default();
+    let client = setup(&env);
+    let voter = Address::generate(&env);
+
+    env.mock_all_auths();
+    tokenize(&client, &env, 1, &voter);
+
+    client.cast_vote(&1u64, &1u64, &voter);
+    // second vote must panic with AlreadyVoted (#22)
+    client.cast_vote(&1u64, &1u64, &voter);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #21)")]
+fn test_cast_vote_below_threshold_panics() {
+    let env = Env::default();
+    let client = setup(&env);
+    let tokenizer = Address::generate(&env);
+    let low_voter = Address::generate(&env);
+
+    env.mock_all_auths();
+    // min_voting_threshold = 500_000; low_voter gets only 50 tokens
+    client.tokenize_asset(
+        &1u64,
+        &String::from_str(&env, "VOT"),
+        &1_000_000i128,
+        &6u32,
+        &500_000i128, // high threshold
+        &tokenizer,
+        &String::from_str(&env, "Vote Token"),
+        &String::from_str(&env, "Voting test asset"),
+        &AssetType::Physical,
+    );
+
+    // Transfer a tiny amount to low_voter
+    client.transfer_tokens(&1u64, &tokenizer, &low_voter, &50i128);
+
+    // low_voter has 50 tokens, threshold is 500_000 — should panic with InsufficientVotingPower (#21)
+    client.cast_vote(&1u64, &1u64, &low_voter);
+}
+
+#[test]
+fn test_proposal_passed_with_majority() {
+    let env = Env::default();
+    let client = setup(&env);
+    let voter = Address::generate(&env);
+
+    env.mock_all_auths();
+    tokenize(&client, &env, 1, &voter);
+
+    client.cast_vote(&1u64, &1u64, &voter);
+
+    // voter holds 100% of supply — proposal must pass
+    assert!(client.proposal_passed(&1u64, &1u64).unwrap());
+}

--- a/frontend/app/(dashboard)/assets/[id]/page.tsx
+++ b/frontend/app/(dashboard)/assets/[id]/page.tsx
@@ -1,29 +1,295 @@
-// frontend/app/(public)/assets/[id]/page.tsx
+// frontend/app/(dashboard)/assets/[id]/page.tsx
 "use client";
 
 import { useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { ArrowLeft, Clock, FileText, Hash } from "lucide-react";
+import {
+  ArrowLeft,
+  Clock,
+  FileText,
+  Hash,
+  Wrench,
+  FolderOpen,
+  StickyNote,
+  Pencil,
+  Trash2,
+  ArrowRightLeft,
+  RefreshCw,
+  CheckCircle,
+  Upload,
+  Plus,
+} from "lucide-react";
 import { format } from "date-fns";
 import { Button } from "@/components/ui/button";
 import { StatusBadge } from "@/components/assets/status-badge";
 import { ConditionBadge } from "@/components/assets/condition-badge";
-import { useAsset, useAssetHistory } from "@/lib/query/hooks/useAsset";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import {
+  useAsset,
+  useAssetHistory,
+  useAssetDocuments,
+  useMaintenanceRecords,
+  useAssetNotes,
+  useDeleteAsset,
+  useUploadDocument,
+  useDeleteDocument,
+  useCreateMaintenanceRecord,
+  useUpdateMaintenanceStatus,
+  useCreateNote,
+  useDeleteNote,
+} from "@/lib/query/hooks/useAsset";
+import type { MaintenanceType } from "@/lib/query/types/asset";
 
-type Tab = "overview" | "history";
+type Tab = "overview" | "history" | "maintenance" | "documents" | "notes";
 
+// ── Skeleton ────────────────────────────────────────────────────────────────
+function Skeleton({ className }: { className?: string }) {
+  return (
+    <div className={`animate-pulse bg-gray-100 rounded-md ${className ?? ""}`} />
+  );
+}
+
+// ── DetailRow ────────────────────────────────────────────────────────────────
+function DetailRow({
+  label,
+  value,
+  fallback = "—",
+}: {
+  label: string;
+  value?: string | null;
+  fallback?: string;
+}) {
+  return (
+    <div className="flex justify-between text-sm">
+      <dt className="text-gray-500">{label}</dt>
+      <dd className="text-gray-900 font-medium text-right">{value || fallback}</dd>
+    </div>
+  );
+}
+
+// ── ActionBadge ──────────────────────────────────────────────────────────────
+const actionColors: Record<string, string> = {
+  CREATED: "bg-green-100 text-green-700",
+  UPDATED: "bg-blue-100 text-blue-700",
+  STATUS_CHANGED: "bg-yellow-100 text-yellow-700",
+  TRANSFERRED: "bg-purple-100 text-purple-700",
+  MAINTENANCE: "bg-orange-100 text-orange-700",
+  NOTE_ADDED: "bg-gray-100 text-gray-600",
+  DOCUMENT_UPLOADED: "bg-teal-100 text-teal-700",
+};
+
+function ActionBadge({ action }: { action: string }) {
+  const cls = actionColors[action] ?? "bg-gray-100 text-gray-600";
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium ${cls}`}>
+      {action.replace(/_/g, " ")}
+    </span>
+  );
+}
+
+// ── MaintenanceStatusBadge ───────────────────────────────────────────────────
+const maintenanceStatusColors: Record<string, string> = {
+  SCHEDULED: "bg-blue-100 text-blue-700",
+  IN_PROGRESS: "bg-yellow-100 text-yellow-700",
+  COMPLETED: "bg-green-100 text-green-700",
+  CANCELLED: "bg-gray-100 text-gray-500",
+};
+
+function MaintenanceStatusBadge({ status }: { status: string }) {
+  const cls = maintenanceStatusColors[status] ?? "bg-gray-100 text-gray-500";
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium ${cls}`}>
+      {status.replace(/_/g, " ")}
+    </span>
+  );
+}
+
+// ── ScheduleMaintenanceModal ─────────────────────────────────────────────────
+function ScheduleMaintenanceModal({
+  assetId,
+  onClose,
+}: {
+  assetId: string;
+  onClose: () => void;
+}) {
+  const [form, setForm] = useState({
+    type: "PREVENTIVE" as MaintenanceType,
+    description: "",
+    scheduledDate: "",
+    notes: "",
+  });
+  const { mutate, isPending } = useCreateMaintenanceRecord(assetId, {
+    onSuccess: onClose,
+  });
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+      <div className="relative bg-white rounded-2xl shadow-xl w-full max-w-md p-6">
+        <h3 className="text-base font-semibold text-gray-900 mb-4">
+          Schedule Maintenance
+        </h3>
+        <div className="space-y-3">
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">Type</label>
+            <select
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
+              value={form.type}
+              onChange={(e) => setForm({ ...form, type: e.target.value as MaintenanceType })}
+            >
+              <option value="PREVENTIVE">Preventive</option>
+              <option value="CORRECTIVE">Corrective</option>
+              <option value="SCHEDULED">Scheduled</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">Description</label>
+            <input
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
+              value={form.description}
+              onChange={(e) => setForm({ ...form, description: e.target.value })}
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">Scheduled Date</label>
+            <input
+              type="date"
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
+              value={form.scheduledDate}
+              onChange={(e) => setForm({ ...form, scheduledDate: e.target.value })}
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">Notes</label>
+            <textarea
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
+              rows={2}
+              value={form.notes}
+              onChange={(e) => setForm({ ...form, notes: e.target.value })}
+            />
+          </div>
+        </div>
+        <div className="flex gap-3 mt-5">
+          <Button variant="outline" className="flex-1" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            className="flex-1"
+            loading={isPending}
+            onClick={() =>
+              mutate({
+                type: form.type,
+                description: form.description,
+                scheduledDate: form.scheduledDate,
+                notes: form.notes || undefined,
+              })
+            }
+          >
+            Schedule
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── UploadDocumentModal ──────────────────────────────────────────────────────
+function UploadDocumentModal({
+  assetId,
+  onClose,
+}: {
+  assetId: string;
+  onClose: () => void;
+}) {
+  const [file, setFile] = useState<File | null>(null);
+  const [name, setName] = useState("");
+  const { mutate: upload, isPending: uploading } = useUploadDocument(assetId, {
+    onSuccess: onClose,
+  });
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+      <div className="relative bg-white rounded-2xl shadow-xl w-full max-w-md p-6">
+        <h3 className="text-base font-semibold text-gray-900 mb-4">Upload Document</h3>
+        <div className="space-y-3">
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">Name (optional)</label>
+            <input
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">File</label>
+            <input
+              type="file"
+              className="w-full text-sm"
+              onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+            />
+          </div>
+        </div>
+        <div className="flex gap-3 mt-5">
+          <Button variant="outline" className="flex-1" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            className="flex-1"
+            loading={uploading}
+            disabled={!file}
+            onClick={() => file && upload({ file, name: name || undefined })}
+          >
+            Upload
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Main Page ────────────────────────────────────────────────────────────────
 export default function AssetDetailPage() {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const [tab, setTab] = useState<Tab>("overview");
 
+  // Confirm dialogs
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [confirmDeleteDoc, setConfirmDeleteDoc] = useState<string | null>(null);
+  const [confirmDeleteNote, setConfirmDeleteNote] = useState<string | null>(null);
+
+  // Modals
+  const [showScheduleMaintenance, setShowScheduleMaintenance] = useState(false);
+  const [showUploadDoc, setShowUploadDoc] = useState(false);
+
+  // Note form
+  const [noteContent, setNoteContent] = useState("");
+
+  // Queries
   const { data: asset, isLoading } = useAsset(id);
-  const { data: history = [] } = useAssetHistory(id);
+  const { data: history = [], isLoading: historyLoading } = useAssetHistory(id);
+  const { data: maintenance = [], isLoading: maintenanceLoading } = useMaintenanceRecords(id);
+  const { data: documents = [], isLoading: documentsLoading } = useAssetDocuments(id);
+  const { data: notes = [], isLoading: notesLoading } = useAssetNotes(id);
+
+  // Mutations
+  const { mutate: deleteAsset, isPending: deletingAsset } = useDeleteAsset(id, {
+    onSuccess: () => router.push("/assets"),
+  });
+  const { mutate: deleteDoc, isPending: deletingDoc } = useDeleteDocument(id);
+  const { mutate: deleteNote, isPending: deletingNote } = useDeleteNote(id);
+  const { mutate: markComplete, isPending: markingComplete } = useUpdateMaintenanceStatus(id);
+  const { mutate: addNote, isPending: addingNote } = useCreateNote(id, {
+    onSuccess: () => setNoteContent(""),
+  });
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center py-24 text-gray-400 text-sm">
-        Loading asset...
+      <div className="space-y-4">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-64 w-full" />
       </div>
     );
   }
@@ -42,6 +308,9 @@ export default function AssetDetailPage() {
   const tabs: { key: Tab; label: string; icon: React.ReactNode }[] = [
     { key: "overview", label: "Overview", icon: <FileText size={15} /> },
     { key: "history", label: "History", icon: <Clock size={15} /> },
+    { key: "maintenance", label: "Maintenance", icon: <Wrench size={15} /> },
+    { key: "documents", label: "Documents", icon: <FolderOpen size={15} /> },
+    { key: "notes", label: "Notes", icon: <StickyNote size={15} /> },
   ];
 
   return (
@@ -57,7 +326,7 @@ export default function AssetDetailPage() {
 
       {/* Header */}
       <div className="bg-white rounded-xl border border-gray-200 px-6 py-5 mb-4">
-        <div className="flex items-start justify-between">
+        <div className="flex items-start justify-between flex-wrap gap-3">
           <div>
             <div className="flex items-center gap-2 mb-1">
               <span className="font-mono text-xs text-gray-400 flex items-center gap-1">
@@ -73,16 +342,35 @@ export default function AssetDetailPage() {
               <ConditionBadge condition={asset.condition} />
             </div>
           </div>
+          <div className="flex items-center gap-2 flex-wrap">
+            <Button size="sm" variant="outline">
+              <ArrowRightLeft size={14} className="mr-1.5" /> Transfer
+            </Button>
+            <Button size="sm" variant="outline">
+              <RefreshCw size={14} className="mr-1.5" /> Update Status
+            </Button>
+            <Button size="sm" variant="outline">
+              <Pencil size={14} className="mr-1.5" /> Edit
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              className="!text-red-600 !border-red-200 hover:!bg-red-50"
+              onClick={() => setConfirmDelete(true)}
+            >
+              <Trash2 size={14} className="mr-1.5" /> Delete
+            </Button>
+          </div>
         </div>
       </div>
 
       {/* Tabs */}
-      <div className="flex gap-1 mb-4 border-b border-gray-200">
+      <div className="flex gap-1 mb-4 border-b border-gray-200 overflow-x-auto">
         {tabs.map(({ key, label, icon }) => (
           <button
             key={key}
             onClick={() => setTab(key)}
-            className={`flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium border-b-2 transition-colors -mb-px ${
+            className={`flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium border-b-2 transition-colors -mb-px whitespace-nowrap ${
               tab === key
                 ? "border-gray-900 text-gray-900"
                 : "border-transparent text-gray-500 hover:text-gray-700"
@@ -94,22 +382,17 @@ export default function AssetDetailPage() {
         ))}
       </div>
 
-      {/* Tab content */}
+      {/* ── Overview ── */}
       {tab === "overview" && (
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-          {/* Basic info */}
           <div className="bg-white rounded-xl border border-gray-200 p-5">
-            <h2 className="text-sm font-semibold text-gray-900 mb-4">
-              Asset Details
-            </h2>
+            <h2 className="text-sm font-semibold text-gray-900 mb-4">Asset Details</h2>
             <dl className="space-y-3">
               <DetailRow label="Category" value={asset.category?.name} />
               <DetailRow label="Department" value={asset.department?.name} />
               <DetailRow
                 label="Assigned To"
-                value={
-                  asset.assignedTo ? `${asset.assignedTo.name}` : undefined
-                }
+                value={asset.assignedTo ? asset.assignedTo.name : undefined}
                 fallback="Unassigned"
               />
               <DetailRow label="Location" value={asset.location} />
@@ -119,11 +402,8 @@ export default function AssetDetailPage() {
             </dl>
           </div>
 
-          {/* Financial info */}
           <div className="bg-white rounded-xl border border-gray-200 p-5">
-            <h2 className="text-sm font-semibold text-gray-900 mb-4">
-              Financial & Dates
-            </h2>
+            <h2 className="text-sm font-semibold text-gray-900 mb-4">Financial & Dates</h2>
             <dl className="space-y-3">
               <DetailRow
                 label="Purchase Price"
@@ -168,14 +448,11 @@ export default function AssetDetailPage() {
             </dl>
           </div>
 
-          {/* Tags & notes */}
           {(asset.tags?.length || asset.notes) && (
             <div className="bg-white rounded-xl border border-gray-200 p-5 lg:col-span-2">
               {asset.tags && asset.tags.length > 0 && (
                 <div className="mb-4">
-                  <h2 className="text-sm font-semibold text-gray-900 mb-2">
-                    Tags
-                  </h2>
+                  <h2 className="text-sm font-semibold text-gray-900 mb-2">Tags</h2>
                   <div className="flex flex-wrap gap-1.5">
                     {asset.tags.map((tag) => (
                       <span
@@ -190,12 +467,8 @@ export default function AssetDetailPage() {
               )}
               {asset.notes && (
                 <div>
-                  <h2 className="text-sm font-semibold text-gray-900 mb-2">
-                    Notes
-                  </h2>
-                  <p className="text-sm text-gray-600 whitespace-pre-wrap">
-                    {asset.notes}
-                  </p>
+                  <h2 className="text-sm font-semibold text-gray-900 mb-2">Notes</h2>
+                  <p className="text-sm text-gray-600 whitespace-pre-wrap">{asset.notes}</p>
                 </div>
               )}
             </div>
@@ -203,23 +476,27 @@ export default function AssetDetailPage() {
         </div>
       )}
 
+      {/* ── History ── */}
       {tab === "history" && (
         <div className="bg-white rounded-xl border border-gray-200 p-5">
-          <h2 className="text-sm font-semibold text-gray-900 mb-4">
-            Change History
-          </h2>
-          {history.length === 0 ? (
-            <p className="text-sm text-gray-400 text-center py-8">
-              No history recorded yet.
-            </p>
+          <h2 className="text-sm font-semibold text-gray-900 mb-4">Change History</h2>
+          {historyLoading ? (
+            <div className="space-y-4">
+              {[1, 2, 3].map((i) => (
+                <Skeleton key={i} className="h-12 w-full" />
+              ))}
+            </div>
+          ) : history.length === 0 ? (
+            <p className="text-sm text-gray-400 text-center py-8">No history recorded yet.</p>
           ) : (
             <ol className="relative border-l border-gray-200 ml-3 space-y-6">
               {history.map((event) => (
                 <li key={event.id} className="ml-4">
                   <div className="absolute -left-1.5 mt-1.5 w-3 h-3 rounded-full bg-gray-300 border-2 border-white" />
-                  <p className="text-sm font-medium text-gray-900">
-                    {event.description}
-                  </p>
+                  <div className="flex items-center gap-2 mb-0.5">
+                    <ActionBadge action={event.action} />
+                  </div>
+                  <p className="text-sm text-gray-900">{event.description}</p>
                   <p className="text-xs text-gray-400 mt-0.5">
                     {format(new Date(event.createdAt), "MMM d, yyyy · h:mm a")}
                     {event.performedBy && ` · ${event.performedBy.name}`}
@@ -230,25 +507,218 @@ export default function AssetDetailPage() {
           )}
         </div>
       )}
-    </div>
-  );
-}
 
-function DetailRow({
-  label,
-  value,
-  fallback = "—",
-}: {
-  label: string;
-  value?: string | null;
-  fallback?: string;
-}) {
-  return (
-    <div className="flex justify-between text-sm">
-      <dt className="text-gray-500">{label}</dt>
-      <dd className="text-gray-900 font-medium text-right">
-        {value || fallback}
-      </dd>
+      {/* ── Maintenance ── */}
+      {tab === "maintenance" && (
+        <div className="bg-white rounded-xl border border-gray-200 p-5">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-sm font-semibold text-gray-900">Maintenance Records</h2>
+            <Button size="sm" onClick={() => setShowScheduleMaintenance(true)}>
+              <Plus size={14} className="mr-1.5" /> Schedule Maintenance
+            </Button>
+          </div>
+          {maintenanceLoading ? (
+            <div className="space-y-3">
+              {[1, 2].map((i) => <Skeleton key={i} className="h-16 w-full" />)}
+            </div>
+          ) : maintenance.length === 0 ? (
+            <p className="text-sm text-gray-400 text-center py-8">No maintenance records.</p>
+          ) : (
+            <div className="space-y-3">
+              {maintenance.map((record) => (
+                <div
+                  key={record.id}
+                  className="flex items-start justify-between border border-gray-100 rounded-lg p-4"
+                >
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium text-gray-900">{record.type}</span>
+                      <MaintenanceStatusBadge status={record.status} />
+                    </div>
+                    <p className="text-sm text-gray-600">{record.description}</p>
+                    <p className="text-xs text-gray-400">
+                      Scheduled: {format(new Date(record.scheduledDate), "MMM d, yyyy")}
+                      {record.cost != null && ` · $${Number(record.cost).toLocaleString()}`}
+                    </p>
+                  </div>
+                  {record.status !== "COMPLETED" && record.status !== "CANCELLED" && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      loading={markingComplete}
+                      onClick={() =>
+                        markComplete({ maintenanceId: record.id, status: "COMPLETED" })
+                      }
+                    >
+                      <CheckCircle size={14} className="mr-1.5" /> Mark Complete
+                    </Button>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ── Documents ── */}
+      {tab === "documents" && (
+        <div className="bg-white rounded-xl border border-gray-200 p-5">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-sm font-semibold text-gray-900">Documents</h2>
+            <Button size="sm" onClick={() => setShowUploadDoc(true)}>
+              <Upload size={14} className="mr-1.5" /> Upload Document
+            </Button>
+          </div>
+          {documentsLoading ? (
+            <div className="space-y-3">
+              {[1, 2].map((i) => <Skeleton key={i} className="h-14 w-full" />)}
+            </div>
+          ) : documents.length === 0 ? (
+            <p className="text-sm text-gray-400 text-center py-8">No documents uploaded.</p>
+          ) : (
+            <div className="space-y-2">
+              {documents.map((doc) => (
+                <div
+                  key={doc.id}
+                  className="flex items-center justify-between border border-gray-100 rounded-lg px-4 py-3"
+                >
+                  <div>
+                    <p className="text-sm font-medium text-gray-900">{doc.name}</p>
+                    <p className="text-xs text-gray-400">
+                      {doc.type} · {(doc.size / 1024).toFixed(1)} KB ·{" "}
+                      {format(new Date(doc.createdAt), "MMM d, yyyy")}
+                    </p>
+                  </div>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="!text-red-500"
+                    onClick={() => setConfirmDeleteDoc(doc.id)}
+                  >
+                    <Trash2 size={14} />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ── Notes ── */}
+      {tab === "notes" && (
+        <div className="space-y-4">
+          <div className="bg-white rounded-xl border border-gray-200 p-5">
+            <h2 className="text-sm font-semibold text-gray-900 mb-3">Add Note</h2>
+            <textarea
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm resize-none"
+              rows={3}
+              placeholder="Write a note..."
+              value={noteContent}
+              onChange={(e) => setNoteContent(e.target.value)}
+            />
+            <div className="flex justify-end mt-2">
+              <Button
+                size="sm"
+                loading={addingNote}
+                disabled={!noteContent.trim()}
+                onClick={() => addNote({ content: noteContent.trim() })}
+              >
+                Add Note
+              </Button>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-xl border border-gray-200 p-5">
+            <h2 className="text-sm font-semibold text-gray-900 mb-4">Notes</h2>
+            {notesLoading ? (
+              <div className="space-y-3">
+                {[1, 2].map((i) => <Skeleton key={i} className="h-16 w-full" />)}
+              </div>
+            ) : notes.length === 0 ? (
+              <p className="text-sm text-gray-400 text-center py-8">No notes yet.</p>
+            ) : (
+              <div className="space-y-3">
+                {notes.map((note) => (
+                  <div
+                    key={note.id}
+                    className="border border-gray-100 rounded-lg p-4"
+                  >
+                    <div className="flex items-start justify-between gap-2">
+                      <p className="text-sm text-gray-800 whitespace-pre-wrap flex-1">
+                        {note.content}
+                      </p>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="!text-red-500 shrink-0"
+                        onClick={() => setConfirmDeleteNote(note.id)}
+                      >
+                        <Trash2 size={14} />
+                      </Button>
+                    </div>
+                    <p className="text-xs text-gray-400 mt-1.5">
+                      {note.createdBy.name} ·{" "}
+                      {format(new Date(note.createdAt), "MMM d, yyyy · h:mm a")}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* ── Confirm Dialogs ── */}
+      {confirmDelete && (
+        <ConfirmDialog
+          title="Delete Asset"
+          message="This will permanently delete the asset and all associated records. This action cannot be undone."
+          confirmLabel="Delete"
+          loading={deletingAsset}
+          onConfirm={() => deleteAsset()}
+          onCancel={() => setConfirmDelete(false)}
+        />
+      )}
+
+      {confirmDeleteDoc && (
+        <ConfirmDialog
+          title="Delete Document"
+          message="Are you sure you want to delete this document?"
+          confirmLabel="Delete"
+          loading={deletingDoc}
+          onConfirm={() => {
+            deleteDoc(confirmDeleteDoc);
+            setConfirmDeleteDoc(null);
+          }}
+          onCancel={() => setConfirmDeleteDoc(null)}
+        />
+      )}
+
+      {confirmDeleteNote && (
+        <ConfirmDialog
+          title="Delete Note"
+          message="Are you sure you want to delete this note?"
+          confirmLabel="Delete"
+          loading={deletingNote}
+          onConfirm={() => {
+            deleteNote(confirmDeleteNote);
+            setConfirmDeleteNote(null);
+          }}
+          onCancel={() => setConfirmDeleteNote(null)}
+        />
+      )}
+
+      {/* ── Modals ── */}
+      {showScheduleMaintenance && (
+        <ScheduleMaintenanceModal
+          assetId={id}
+          onClose={() => setShowScheduleMaintenance(false)}
+        />
+      )}
+
+      {showUploadDoc && (
+        <UploadDocumentModal assetId={id} onClose={() => setShowUploadDoc(false)} />
+      )}
     </div>
   );
 }

--- a/frontend/lib/api/assets.ts
+++ b/frontend/lib/api/assets.ts
@@ -135,4 +135,16 @@ export const assetApiClient = {
 
   createNote: (assetId: string, data: CreateNoteInput): Promise<AssetNote> =>
     api.post<AssetNote>(`/assets/${assetId}/notes`, data).then((r) => r.data),
+
+  deleteNote: (assetId: string, noteId: string): Promise<void> =>
+    api.delete(`/assets/${assetId}/notes/${noteId}`).then(() => undefined),
+
+  updateMaintenanceStatus: (
+    assetId: string,
+    maintenanceId: string,
+    status: string,
+  ): Promise<MaintenanceRecord> =>
+    api
+      .patch<MaintenanceRecord>(`/assets/${assetId}/maintenance/${maintenanceId}`, { status })
+      .then((r) => r.data),
 };

--- a/frontend/lib/query/hooks/useAsset.ts
+++ b/frontend/lib/query/hooks/useAsset.ts
@@ -216,3 +216,34 @@ export function useCreateNote(
     ...options,
   });
 }
+
+export function useDeleteNote(
+  assetId: string,
+  options?: UseMutationOptions<void, ApiError, string>
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, ApiError, string>({
+    mutationFn: (noteId) => assetApiClient.deleteNote(assetId, noteId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.assets.notes(assetId) });
+    },
+    ...options,
+  });
+}
+
+export function useUpdateMaintenanceStatus(
+  assetId: string,
+  options?: UseMutationOptions<MaintenanceRecord, ApiError, { maintenanceId: string; status: string }>
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation<MaintenanceRecord, ApiError, { maintenanceId: string; status: string }>({
+    mutationFn: ({ maintenanceId, status }) =>
+      assetApiClient.updateMaintenanceStatus(assetId, maintenanceId, status),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.assets.maintenance(assetId) });
+    },
+    ...options,
+  });
+}


### PR DESCRIPTION
Closes #626, 
Closes #627, 
Closes #628, 
Closes #665

## Changes

**Frontend**
- Asset detail page with 5 tabs: Overview, History, Maintenance, Documents, Notes
- Overview: two-column card layout with status/condition badges and action buttons (Transfer, Update Status, Edit, Delete)
- History: timeline with action badges, loading skeleton, empty state
- Maintenance: list with status badges, Mark Complete button, Schedule Maintenance modal
- Documents: list with upload date/size, Upload Document modal, delete with confirm dialog
- Notes: add note textarea, note cards with delete confirm dialog
- Added `deleteNote` and `updateMaintenanceStatus` to assets API client
- Added `useDeleteNote` and `useUpdateMaintenanceStatus` hooks

**Contracts**
- Moved `contracts/contrib/src/tests.rs` → `tests/mod.rs`
- Added `assetsup` as dev-dependency in `contracts/contrib`
- New test files in `contracts/contrib/src/tests/`:
  - `tokenization.rs`: tokenize success, already-tokenized panic, transfer success, insufficient balance panic, blacklisted recipient panic
  - `voting.rs`: cast vote success, double-vote panic, below-threshold panic, proposal passed
  - `dividends.rs`: single-holder distribute+claim, proportional multi-holder distribution, no-dividends-to-claim panic
  - `detokenization.rs`: end-to-end proposal→vote→execute flow, no-votes panic, duplicate proposal panic