### PR TITLE
feat: users management, reports charts, export buttons and settings page

### DIFF
--- a/frontend/contrib/app/(dashboard)/reports/page.tsx
+++ b/frontend/contrib/app/(dashboard)/reports/page.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { FileArrowDown, BarChart3 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { EmptyState } from '@/components/ui/empty-state';
+import { LoadingSkeleton } from '@/components/ui/loading-skeleton';
+import { ToastProvider, toast } from '@/components/ui/toast';
+import { api } from '@/lib/api';
+import { useReportsSummary } from '@/lib/query/hooks';
+
+function downloadBlob(filename: string, blob: Blob) {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}
+
+export default function ReportsPage() {
+  const { data: summary, isLoading } = useReportsSummary();
+  const [exporting, setExporting] = useState({ excel: false, pdf: false });
+
+  const statusData = useMemo(() => {
+    if (!summary) return [];
+    return Object.entries(summary.byStatus).map(([status, count]) => ({ status, count }));
+  }, [summary]);
+
+  const topCategories = useMemo(() => {
+    if (!summary) return [];
+    return [...summary.byCategory].sort((a, b) => b.count - a.count).slice(0, 5);
+  }, [summary]);
+
+  const topDepartments = useMemo(() => {
+    if (!summary) return [];
+    return [...summary.byDepartment].sort((a, b) => b.count - a.count).slice(0, 5);
+  }, [summary]);
+
+  const handleExport = async (type: 'excel' | 'pdf') => {
+    setExporting((prev) => ({ ...prev, [type]: true }));
+
+    try {
+      const response = await api.get(`/reports/export/${type}`, { responseType: 'blob' });
+      const contentType = type === 'excel' ? 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' : 'application/pdf';
+      const filename = `asset-report.${type === 'excel' ? 'xlsx' : 'pdf'}`;
+      const blob = new Blob([response.data], { type: contentType });
+      downloadBlob(filename, blob);
+      toast.success(`${type === 'excel' ? 'Excel' : 'PDF'} export started`);
+    } catch (error) {
+      toast.error(`Failed to export ${type.toUpperCase()}`);
+    } finally {
+      setExporting((prev) => ({ ...prev, [type]: false }));
+    }
+  };
+
+  return (
+    <div>
+      <ToastProvider />
+
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Reports</h1>
+          <p className="text-sm text-gray-500 mt-1">Review asset health and department performance.</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="md"
+            loading={exporting.excel}
+            onClick={() => handleExport('excel')}
+          >
+            <FileArrowDown size={16} />
+            Export Excel
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="md"
+            loading={exporting.pdf}
+            onClick={() => handleExport('pdf')}
+          >
+            <FileArrowDown size={16} />
+            Export PDF
+          </Button>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <LoadingSkeleton rows={5} columns={1} />
+      ) : !summary ? (
+        <EmptyState
+          title="No reports available"
+          description="No data is available for the selected period. Check back after assets are added."
+        />
+      ) : (
+        <div className="space-y-6">
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+            <div className="rounded-3xl border border-gray-200 bg-white p-6">
+              <p className="text-sm font-semibold text-gray-500">Total Assets</p>
+              <p className="mt-3 text-3xl font-semibold text-gray-900">{summary.total}</p>
+            </div>
+            {Object.entries(summary.byStatus).map(([status, count]) => (
+              <div key={status} className="rounded-3xl border border-gray-200 bg-white p-6">
+                <p className="text-sm font-semibold text-gray-500">{status}</p>
+                <p className="mt-3 text-3xl font-semibold text-gray-900">{count}</p>
+              </div>
+            ))}
+          </div>
+
+          <div className="grid gap-6 lg:grid-cols-[1.45fr_1fr]">
+            <div className="rounded-3xl border border-gray-200 bg-white p-6">
+              <div className="flex items-center gap-2 mb-4 text-gray-900">
+                <BarChart3 size={18} />
+                <h2 className="text-lg font-semibold">Assets by status</h2>
+              </div>
+              <div className="h-[320px]">
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={statusData} margin={{ top: 8, right: 16, left: -12, bottom: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" vertical={false} />
+                    <XAxis dataKey="status" axisLine={false} tickLine={false} />
+                    <YAxis allowDecimals={false} axisLine={false} tickLine={false} />
+                    <Tooltip />
+                    <Bar dataKey="count" fill="#111827" radius={[8, 8, 0, 0]} />
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            </div>
+
+            <div className="space-y-6">
+              <div className="rounded-3xl border border-gray-200 bg-white p-6">
+                <h3 className="text-base font-semibold text-gray-900 mb-4">Top 5 categories</h3>
+                {topCategories.length === 0 ? (
+                  <p className="text-sm text-gray-500">No category data available.</p>
+                ) : (
+                  <div className="space-y-3">
+                    {topCategories.map((category) => (
+                      <div key={category.name} className="flex items-center justify-between gap-3 rounded-2xl bg-slate-50 px-4 py-3">
+                        <span className="text-sm text-gray-900">{category.name}</span>
+                        <span className="text-sm font-semibold text-gray-900">{category.count}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+              <div className="rounded-3xl border border-gray-200 bg-white p-6">
+                <h3 className="text-base font-semibold text-gray-900 mb-4">Top 5 departments</h3>
+                {topDepartments.length === 0 ? (
+                  <p className="text-sm text-gray-500">No department data available.</p>
+                ) : (
+                  <div className="space-y-3">
+                    {topDepartments.map((department) => (
+                      <div key={department.name} className="flex items-center justify-between gap-3 rounded-2xl bg-slate-50 px-4 py-3">
+                        <span className="text-sm text-gray-900">{department.name}</span>
+                        <span className="text-sm font-semibold text-gray-900">{department.count}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/contrib/app/(dashboard)/settings/page.tsx
+++ b/frontend/contrib/app/(dashboard)/settings/page.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { LoadingSkeleton } from '@/components/ui/loading-skeleton';
+import { ToastProvider, toast } from '@/components/ui/toast';
+import { useAuthStore } from '@/contrib/store/auth.store';
+import { api } from '@/lib/api';
+
+const profileSchema = z.object({
+  firstName: z.string().min(1, 'First name is required'),
+  lastName: z.string().min(1, 'Last name is required'),
+});
+
+const passwordSchema = z
+  .object({
+    currentPassword: z.string().min(1, 'Current password is required'),
+    newPassword: z.string().min(8, 'New password must be at least 8 characters'),
+    confirmPassword: z.string().min(1, 'Please confirm your new password'),
+  })
+  .superRefine(({ newPassword, confirmPassword }, ctx) => {
+    if (newPassword !== confirmPassword) {
+      ctx.addIssue({
+        path: ['confirmPassword'],
+        message: 'Passwords must match',
+        code: 'custom',
+      });
+    }
+  });
+
+type ProfileValues = z.infer<typeof profileSchema>;
+type PasswordValues = z.infer<typeof passwordSchema>;
+
+export default function SettingsPage() {
+  const user = useAuthStore((state) => state.user);
+  const setUser = useAuthStore((state) => state.setUser);
+  const [profileError, setProfileError] = useState('');
+  const [passwordError, setPasswordError] = useState('');
+
+  const {
+    register: registerProfile,
+    handleSubmit: handleProfileSubmit,
+    formState: { errors: profileErrors, isSubmitting: isProfileSaving },
+    reset: resetProfile,
+  } = useForm<ProfileValues>({
+    resolver: zodResolver(profileSchema),
+    defaultValues: {
+      firstName: user?.firstName ?? '',
+      lastName: user?.lastName ?? '',
+    },
+  });
+
+  const {
+    register: registerPassword,
+    handleSubmit: handlePasswordSubmit,
+    formState: { errors: passwordErrors, isSubmitting: isPasswordSaving },
+    reset: resetPassword,
+  } = useForm<PasswordValues>({
+    resolver: zodResolver(passwordSchema),
+  });
+
+  useEffect(() => {
+    if (user) {
+      resetProfile({ firstName: user.firstName, lastName: user.lastName });
+    }
+  }, [user, resetProfile]);
+
+  const onSaveProfile = async (values: ProfileValues) => {
+    setProfileError('');
+    try {
+      const updated = await api.patch('/users/me', values).then((res) => res.data);
+      setUser({ ...user, ...updated });
+      toast.success('Profile updated successfully');
+    } catch (error: unknown) {
+      const message =
+        (error as { response?: { data?: { message?: string } } })?.response?.data?.message ||
+        'Unable to update profile';
+      setProfileError(message);
+    }
+  };
+
+  const onChangePassword = async (values: PasswordValues) => {
+    setPasswordError('');
+    try {
+      await api.patch('/users/me', {
+        currentPassword: values.currentPassword,
+        newPassword: values.newPassword,
+      });
+      resetPassword();
+      toast.success('Password changed successfully');
+    } catch (error: unknown) {
+      const message =
+        (error as { response?: { data?: { message?: string } } })?.response?.data?.message ||
+        'Unable to change password';
+      setPasswordError(message);
+    }
+  };
+
+  if (!user) {
+    return <LoadingSkeleton rows={4} columns={1} />;
+  }
+
+  return (
+    <div>
+      <ToastProvider />
+
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">Settings</h1>
+        <p className="text-sm text-gray-500 mt-1">Update profile information and manage your password.</p>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
+        <section className="rounded-3xl border border-gray-200 bg-white p-6">
+          <div className="mb-6">
+            <h2 className="text-xl font-semibold text-gray-900">Profile Information</h2>
+            <p className="text-sm text-gray-500 mt-1">Update your display name and account details.</p>
+          </div>
+
+          <form onSubmit={handleProfileSubmit(onSaveProfile)} className="space-y-4">
+            <Input
+              label="First Name"
+              {...registerProfile('firstName')}
+              error={profileErrors.firstName?.message}
+            />
+            <Input
+              label="Last Name"
+              {...registerProfile('lastName')}
+              error={profileErrors.lastName?.message}
+            />
+            <Input label="Email" value={user.email} disabled />
+
+            {profileError ? (
+              <p className="text-sm text-red-500 bg-red-50 border border-red-200 rounded-lg px-3 py-2">
+                {profileError}
+              </p>
+            ) : null}
+
+            <Button type="submit" loading={isProfileSaving} size="lg">
+              Save profile
+            </Button>
+          </form>
+        </section>
+
+        <section className="rounded-3xl border border-gray-200 bg-white p-6">
+          <div className="mb-6">
+            <h2 className="text-xl font-semibold text-gray-900">Change Password</h2>
+            <p className="text-sm text-gray-500 mt-1">Update your account password to keep your account secure.</p>
+          </div>
+
+          <form onSubmit={handlePasswordSubmit(onChangePassword)} className="space-y-4">
+            <Input
+              label="Current Password"
+              type="password"
+              {...registerPassword('currentPassword')}
+              error={passwordErrors.currentPassword?.message}
+            />
+            <Input
+              label="New Password"
+              type="password"
+              {...registerPassword('newPassword')}
+              error={passwordErrors.newPassword?.message}
+            />
+            <Input
+              label="Confirm New Password"
+              type="password"
+              {...registerPassword('confirmPassword')}
+              error={passwordErrors.confirmPassword?.message}
+            />
+
+            {passwordError ? (
+              <p className="text-sm text-red-500 bg-red-50 border border-red-200 rounded-lg px-3 py-2">
+                {passwordError}
+              </p>
+            ) : null}
+
+            <Button type="submit" loading={isPasswordSaving} size="lg">
+              Save password
+            </Button>
+          </form>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/contrib/app/(dashboard)/users/page.tsx
+++ b/frontend/contrib/app/(dashboard)/users/page.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Search, Users2 } from 'lucide-react';
+import { useQueryClient } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+import { useUsers } from '@/lib/query/hooks';
+import { queryKeys } from '@/lib/query/queryKeys';
+import { useAuthStore } from '@/contrib/store/auth.store';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { LoadingSkeleton } from '@/components/ui/loading-skeleton';
+import { ToastProvider, toast } from '@/components/ui/toast';
+
+const ROLE_OPTIONS = ['All', 'Admin', 'Manager', 'Staff'] as const;
+
+type RoleFilter = (typeof ROLE_OPTIONS)[number];
+
+function formatJoinedDate(isoDate: string) {
+  try {
+    return new Intl.DateTimeFormat('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    }).format(new Date(isoDate));
+  } catch {
+    return isoDate;
+  }
+}
+
+export default function UsersPage() {
+  const queryClient = useQueryClient();
+  const currentUser = useAuthStore((state) => state.user);
+  const { data: users = [], isLoading } = useUsers();
+  const [search, setSearch] = useState('');
+  const [roleFilter, setRoleFilter] = useState<RoleFilter>('All');
+  const [updatingRoles, setUpdatingRoles] = useState<Record<string, boolean>>({});
+
+  const filteredUsers = useMemo(() => {
+    const normalizedSearch = search.trim().toLowerCase();
+    return users
+      .filter((user) => {
+        const matchesSearch =
+          normalizedSearch === '' ||
+          `${user.firstName} ${user.lastName}`.toLowerCase().includes(normalizedSearch) ||
+          user.email.toLowerCase().includes(normalizedSearch);
+        const matchesRole = roleFilter === 'All' || user.role === roleFilter;
+        return matchesSearch && matchesRole;
+      })
+      .sort((a, b) => a.lastName.localeCompare(b.lastName));
+  }, [search, roleFilter, users]);
+
+  const handleRoleChange = async (userId: string, newRole: string) => {
+    setUpdatingRoles((prev) => ({ ...prev, [userId]: true }));
+    try {
+      await api.patch(`/users/${userId}/role`, { role: newRole });
+      await queryClient.invalidateQueries({ queryKey: queryKeys.users.all() });
+      toast.success('User role updated');
+    } catch (error) {
+      toast.error('Unable to update role. Please try again.');
+    } finally {
+      setUpdatingRoles((prev) => ({ ...prev, [userId]: false }));
+    }
+  };
+
+  return (
+    <div>
+      <ToastProvider />
+
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Users</h1>
+          <p className="text-sm text-gray-500 mt-1">Manage platform users, roles, and onboarding.</p>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-[1fr_auto]">
+          <Input
+            type="search"
+            placeholder="Search by name or email"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            leftIcon={<Search size={16} />}
+          />
+          <div className="flex flex-wrap items-center gap-2">
+            {ROLE_OPTIONS.map((role) => (
+              <Button
+                key={role}
+                type="button"
+                variant={roleFilter === role ? 'primary' : 'outline'}
+                size="sm"
+                onClick={() => setRoleFilter(role)}
+              >
+                {role}
+              </Button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="bg-white rounded-3xl border border-gray-200 shadow-sm overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-200 bg-gray-50">
+                <th className="px-4 py-4 text-left font-medium text-gray-500">Name</th>
+                <th className="px-4 py-4 text-left font-medium text-gray-500">Email</th>
+                <th className="px-4 py-4 text-left font-medium text-gray-500">Role</th>
+                <th className="px-4 py-4 text-left font-medium text-gray-500">Joined Date</th>
+              </tr>
+            </thead>
+            <tbody>
+              {isLoading ? (
+                Array.from({ length: 6 }).map((_, index) => (
+                  <tr key={index} className="border-b border-gray-100">
+                    {Array.from({ length: 4 }).map((cell, cellIndex) => (
+                      <td key={cellIndex} className="px-4 py-4">
+                        <div className="h-4 w-full max-w-[10rem] rounded-full bg-gray-100 animate-pulse" />
+                      </td>
+                    ))}
+                  </tr>
+                ))
+              ) : filteredUsers.length === 0 ? (
+                <tr>
+                  <td colSpan={4} className="px-4 py-12 text-center text-gray-500">
+                    {users.length === 0
+                      ? 'No users found. Invite your team to get started.'
+                      : 'No users match your current search and filters.'}
+                  </td>
+                </tr>
+              ) : (
+                filteredUsers.map((user) => {
+                  const isCurrentUser = currentUser?.id === user.id;
+                  const roleUpdating = updatingRoles[user.id] ?? false;
+
+                  return (
+                    <tr
+                      key={user.id}
+                      className="border-b border-gray-100 hover:bg-gray-50 transition-colors"
+                    >
+                      <td className="px-4 py-4 text-gray-900 font-medium">
+                        {user.firstName} {user.lastName}
+                      </td>
+                      <td className="px-4 py-4 text-gray-600">{user.email}</td>
+                      <td className="px-4 py-4">
+                        <select
+                          className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900"
+                          value={user.role}
+                          disabled={isCurrentUser || roleUpdating}
+                          onChange={(event) => handleRoleChange(user.id, event.target.value)}
+                        >
+                          {ROLE_OPTIONS.slice(1).map((option) => (
+                            <option key={option} value={option}>
+                              {option}
+                            </option>
+                          ))}
+                        </select>
+                      </td>
+                      <td className="px-4 py-4 text-gray-600">{formatJoinedDate(user.createdAt)}</td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/contrib/components/ui/toast.tsx
+++ b/frontend/contrib/components/ui/toast.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import { ToastContainer, toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
+
+export { toast };
+
+export function ToastProvider() {
+  return <ToastContainer position="top-right" autoClose={3000} hideProgressBar theme="colored" />;
+}


### PR DESCRIPTION
Changes

### #633 — Users Management Page [FE-28]
- Table: Name, Email, Role (inline select), Joined Date
- Inline \`PATCH /users/:id/role\` on role change
- Role dropdown disabled for authenticated user (no self-demote)
- Client-side search by name or email
- Role filter: All / Admin / Manager / Staff
- Loading skeleton + empty state

### #634 — Reports Page with Statistics Charts [FE-29]
- Summary stat cards (total + per-status counts)
- Horizontal bar chart — assets by status (Recharts)
- Top 5 categories by asset count
- Top 5 departments by asset count
- Fetched from \`GET /reports/summary\`
- Loading skeleton while fetching

### #635 — Excel & PDF Export Buttons [FE-30]
- \`Export Excel\` → \`GET /reports/export/excel\` → \`.xlsx\` download
- \`Export PDF\` → \`GET /reports/export/pdf\` → \`.pdf\` download
- Loading spinner on both buttons during generation
- Toast notification on error
- Buttons in reports page header

### #636 — Settings Page [FE-31]
- Two card sections: Profile Information + Change Password
- Profile form: firstName, lastName → \`PATCH /users/me\`
- Password form: currentPassword, newPassword, confirmPassword → \`PATCH /users/me\`
- Zod validation + inline error messages on both forms
- Success toast on save, inline API error feedback
- Pre-populated from Zustand store

## Test Coverage
- [ ] Users: role change fires PATCH, self-demote blocked, search filters, skeleton
- [ ] Reports: charts render with mock data, skeleton shown on load
- [ ] Export: download triggered, spinner shown, toast on error
- [ ] Settings: Zod validation, success toast, API error inline, Zustand pre-fill

## Closes
Closes #633
Closes #634
Closes #635
Closes #636